### PR TITLE
Max. number of connections can be specified at runtime.

### DIFF
--- a/CGDWebServer/GCDWebServer.h
+++ b/CGDWebServer/GCDWebServer.h
@@ -41,14 +41,14 @@ typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(GCDWebServerRequest* r
 }
 @property(nonatomic, readonly, getter=isRunning) BOOL running;
 @property(nonatomic, readonly) NSUInteger port;
-@property(nonatomic, readonly) int maxPendingConnections;
+@property(nonatomic, readonly) NSUInteger maxPendingConnections;
 
 - (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock processBlock:(GCDWebServerProcessBlock)processBlock;
 - (void)removeAllHandlers;
 
 - (BOOL)start;  // Default is 8080 port and computer name
 - (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name;  // Pass nil name to disable Bonjour or empty string to use computer name
-- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name maxPendingConnections:(int)maxPendingConnections;
+- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name maxPendingConnections:(NSUInteger)maxPendingConnections;
 - (void)stop;
 @end
 

--- a/CGDWebServer/GCDWebServer.m
+++ b/CGDWebServer/GCDWebServer.m
@@ -174,7 +174,7 @@ static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* er
     return [self startWithPort:port bonjourName:name maxPendingConnections:_maxPendingConnections]; // maxPendingConnections defaults to 16
 }
 
-- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name maxPendingConnections:(int)maxPendingConnections {
+- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name maxPendingConnections:(NSUInteger)maxPendingConnections {
     DCHECK(_source == NULL);
     if (maxPendingConnections > SOMAXCONN) {
         // We could truncate maxPendingConnections to SOMAXCONN here but let's not do this. listen(int, int) does that internally already.


### PR DESCRIPTION
I think it makes more sense to have the max. number of connections at a runtime parameter.
