### PR TITLE
Log to stderr, not stdout

### DIFF
--- a/CGDWebServer/GCDWebServerPrivate.h
+++ b/CGDWebServer/GCDWebServerPrivate.h
@@ -62,7 +62,7 @@ static inline void __LogMessage(long level, NSString* format, ...) {
     va_start(arguments, format);
     NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
     va_end(arguments);
-    printf("[%s] %s\n", levelNames[level], [message UTF8String]);
+    fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
     ARC_RELEASE(message);
   }
 }


### PR DESCRIPTION
Log messages should be written to stderr, not stdout.

Logging to stderr caused issues for me when running tests using [xctool](https://github.com/facebook/xctool), which uses stdout to pass json data back to the test runner. Debug messages were written by GCDWebServer to stdout from a background thread, which corrupted the json.
