### PR TITLE
Rename parameters to klass instead of class to prevent parsing issues

### DIFF
--- a/CGDWebServer/GCDWebServer.h
+++ b/CGDWebServer/GCDWebServer.h
@@ -60,8 +60,8 @@ typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(GCDWebServerRequest* r
 @end
 
 @interface GCDWebServer (Handlers)
-- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)class processBlock:(GCDWebServerProcessBlock)block;
+- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)klass processBlock:(GCDWebServerProcessBlock)block;
 - (void)addHandlerForBasePath:(NSString*)basePath localPath:(NSString*)localPath indexFilename:(NSString*)indexFilename cacheAge:(NSUInteger)cacheAge;  // Base path is recursive and case-sensitive
-- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)class processBlock:(GCDWebServerProcessBlock)block;  // Path is case-insensitive
-- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)class processBlock:(GCDWebServerProcessBlock)block;  // Regular expression is case-insensitive
+- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)klass processBlock:(GCDWebServerProcessBlock)block;  // Path is case-insensitive
+- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)klass processBlock:(GCDWebServerProcessBlock)block;  // Regular expression is case-insensitive
 @end


### PR DESCRIPTION
I didn't get to the root cause of this, but this was not compiling for me using Xcode 5.0.2 and CocoaPods.
