### PR TITLE
Prefix log macros to avoid conflicts with e.g. NSLogger

### DIFF
--- a/CGDWebServer/GCDWebServer.m
+++ b/CGDWebServer/GCDWebServer.m
@@ -169,9 +169,9 @@ static void _SignalHandler(int signal) {
 static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* error, void* info) {
   @autoreleasepool {
     if (error->error) {
-      LOG_ERROR(@"Bonjour error %i (domain %i)", error->error, (int)error->domain);
+      GCDWS_LOG_ERROR(@"Bonjour error %i (domain %i)", error->error, (int)error->domain);
     } else {
-      LOG_VERBOSE(@"Registered Bonjour service \"%@\" in domain \"%@\" with type '%@' on port %i", CFNetServiceGetName(service), CFNetServiceGetDomain(service), CFNetServiceGetType(service), CFNetServiceGetPortNumber(service));
+      GCDWS_LOG_VERBOSE(@"Registered Bonjour service \"%@\" in domain \"%@\" with type '%@' on port %i", CFNetServiceGetName(service), CFNetServiceGetDomain(service), CFNetServiceGetType(service), CFNetServiceGetPortNumber(service));
     }
   }
 }
@@ -198,9 +198,9 @@ static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* er
           @autoreleasepool {
             int result = close(listeningSocket);
             if (result != 0) {
-              LOG_ERROR(@"Failed closing socket (%i): %s", errno, strerror(errno));
+              GCDWS_LOG_ERROR(@"Failed closing socket (%i): %s", errno, strerror(errno));
             } else {
-              LOG_DEBUG(@"Closed listening socket");
+              GCDWS_LOG_DEBUG(@"Closed listening socket");
             }
           }
           
@@ -224,7 +224,7 @@ static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* er
               [connection release];
 #endif
             } else {
-              LOG_ERROR(@"Failed accepting socket (%i): %s", errno, strerror(errno));
+              GCDWS_LOG_ERROR(@"Failed accepting socket (%i): %s", errno, strerror(errno));
             }
           }
           
@@ -237,7 +237,7 @@ static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* er
             struct sockaddr_in* sockaddr = (struct sockaddr_in*)&addr;
             _port = ntohs(sockaddr->sin_port);
           } else {
-            LOG_ERROR(@"Failed retrieving socket address (%i): %s", errno, strerror(errno));
+            GCDWS_LOG_ERROR(@"Failed retrieving socket address (%i): %s", errno, strerror(errno));
           }
         } else {
           _port = port;
@@ -252,22 +252,22 @@ static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* er
             CFStreamError error = {0};
             CFNetServiceRegisterWithOptions(_service, 0, &error);
           } else {
-            LOG_ERROR(@"Failed creating CFNetService");
+            GCDWS_LOG_ERROR(@"Failed creating CFNetService");
           }
         }
         
         dispatch_resume(_source);
-        LOG_VERBOSE(@"%@ started on port %i", [self class], (int)_port);
+        GCDWS_LOG_VERBOSE(@"%@ started on port %i", [self class], (int)_port);
       } else {
-        LOG_ERROR(@"Failed listening on socket (%i): %s", errno, strerror(errno));
+        GCDWS_LOG_ERROR(@"Failed listening on socket (%i): %s", errno, strerror(errno));
         close(listeningSocket);
       }
     } else {
-      LOG_ERROR(@"Failed binding socket (%i): %s", errno, strerror(errno));
+      GCDWS_LOG_ERROR(@"Failed binding socket (%i): %s", errno, strerror(errno));
       close(listeningSocket);
     }
   } else {
-    LOG_ERROR(@"Failed creating socket (%i): %s", errno, strerror(errno));
+    GCDWS_LOG_ERROR(@"Failed creating socket (%i): %s", errno, strerror(errno));
   }
   return (_source ? YES : NO);
 }
@@ -290,7 +290,7 @@ static void _NetServiceClientCallBack(CFNetServiceRef service, CFStreamError* er
     ARC_DISPATCH_RELEASE(_source);
     _source = NULL;
     
-    LOG_VERBOSE(@"%@ stopped", [self class]);
+    GCDWS_LOG_VERBOSE(@"%@ stopped", [self class]);
   }
   _port = 0;
 }

--- a/CGDWebServer/GCDWebServerConnection.m
+++ b/CGDWebServer/GCDWebServerConnection.m
@@ -54,19 +54,19 @@ static dispatch_queue_t _formatterQueue = NULL;
       if (error == 0) {
         size_t size = dispatch_data_get_size(buffer);
         if (size > 0) {
-          LOG_DEBUG(@"Connection received %i bytes on socket %i", size, _socket);
+          GCDWS_LOG_DEBUG(@"Connection received %i bytes on socket %i", size, _socket);
           _bytesRead += size;
           block(buffer);
         } else {
           if (_bytesRead > 0) {
-            LOG_ERROR(@"No more data available on socket %i", _socket);
+            GCDWS_LOG_ERROR(@"No more data available on socket %i", _socket);
           } else {
-            LOG_WARNING(@"No data received from socket %i", _socket);
+            GCDWS_LOG_WARNING(@"No data received from socket %i", _socket);
           }
           block(NULL);
         }
       } else {
-        LOG_ERROR(@"Error while reading from socket %i: %s (%i)", _socket, strerror(error), error);
+        GCDWS_LOG_ERROR(@"Error while reading from socket %i: %s (%i)", _socket, strerror(error), error);
         block(NULL);
       }
     }
@@ -107,7 +107,7 @@ static dispatch_queue_t _formatterQueue = NULL;
         if (CFHTTPMessageAppendBytes(_requestMessage, data.bytes, data.length)) {
           [self _readHeadersWithCompletionBlock:block];
         } else {
-          LOG_ERROR(@"Failed appending request headers data from socket %i", _socket);
+          GCDWS_LOG_ERROR(@"Failed appending request headers data from socket %i", _socket);
           block(nil);
         }
       } else {
@@ -116,11 +116,11 @@ static dispatch_queue_t _formatterQueue = NULL;
           if (CFHTTPMessageIsHeaderComplete(_requestMessage)) {
             block([data subdataWithRange:NSMakeRange(length, data.length - length)]);
           } else {
-            LOG_ERROR(@"Failed parsing request headers from socket %i", _socket);
+            GCDWS_LOG_ERROR(@"Failed parsing request headers from socket %i", _socket);
             block(nil);
           }
         } else {
-          LOG_ERROR(@"Failed appending request headers data from socket %i", _socket);
+          GCDWS_LOG_ERROR(@"Failed appending request headers data from socket %i", _socket);
           block(nil);
         }
       }
@@ -141,7 +141,7 @@ static dispatch_queue_t _formatterQueue = NULL;
         bool success = dispatch_data_apply(buffer, ^bool(dispatch_data_t region, size_t offset, const void* buffer, size_t size) {
           NSInteger result = [_request write:buffer maxLength:size];
           if (result != size) {
-            LOG_ERROR(@"Failed writing request body on socket %i (error %i)", _socket, (int)result);
+            GCDWS_LOG_ERROR(@"Failed writing request body on socket %i (error %i)", _socket, (int)result);
             return false;
           }
           return true;
@@ -177,11 +177,11 @@ static dispatch_queue_t _formatterQueue = NULL;
     @autoreleasepool {
       if (error == 0) {
         DCHECK(data == NULL);
-        LOG_DEBUG(@"Connection sent %i bytes on socket %i", size, _socket);
+        GCDWS_LOG_DEBUG(@"Connection sent %i bytes on socket %i", size, _socket);
         _bytesWritten += size;
         block(YES);
       } else {
-        LOG_ERROR(@"Error while writing to socket %i: %s (%i)", _socket, strerror(error), error);
+        GCDWS_LOG_ERROR(@"Error while writing to socket %i: %s (%i)", _socket, strerror(error), error);
         block(NO);
       }
     }
@@ -228,7 +228,7 @@ static dispatch_queue_t _formatterQueue = NULL;
     }];
     ARC_DISPATCH_RELEASE(wrapper);
   } else if (result < 0) {
-    LOG_ERROR(@"Failed reading response body on socket %i (error %i)", _socket, (int)result);
+    GCDWS_LOG_ERROR(@"Failed reading response body on socket %i (error %i)", _socket, (int)result);
     block(NO);
     free(buffer);
   } else {
@@ -289,7 +289,7 @@ static dispatch_queue_t _formatterQueue = NULL;
   [self _writeHeadersWithCompletionBlock:^(BOOL success) {
     ;  // Nothing more to do
   }];
-  LOG_DEBUG(@"Connection aborted with status code %i on socket %i", statusCode, _socket);
+  GCDWS_LOG_DEBUG(@"Connection aborted with status code %i on socket %i", statusCode, _socket);
 }
 
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
@@ -346,7 +346,7 @@ static dispatch_queue_t _formatterQueue = NULL;
         length -= initialData.length;
         DCHECK(length >= 0);
       } else {
-        LOG_ERROR(@"Failed writing request body on socket %i (error %i)", _socket, (int)result);
+        GCDWS_LOG_ERROR(@"Failed writing request body on socket %i (error %i)", _socket, (int)result);
         length = -1;
       }
     }
@@ -417,14 +417,14 @@ static dispatch_queue_t _formatterQueue = NULL;
                   
                 }];
               } else {
-                LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", _socket);
+                GCDWS_LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", _socket);
                 [self _abortWithStatusCode:417];
               }
             } else {
               [self _readRequestBody:extraData];
             }
           } else {
-            LOG_ERROR(@"Unexpected 'Content-Length' header value on socket %i", _socket);
+            GCDWS_LOG_ERROR(@"Unexpected 'Content-Length' header value on socket %i", _socket);
             [self _abortWithStatusCode:400];
           }
         } else {
@@ -475,18 +475,18 @@ static dispatch_queue_t _formatterQueue = NULL;
 @implementation GCDWebServerConnection (Subclassing)
 
 - (void)open {
-  LOG_DEBUG(@"Did open connection on socket %i", _socket);
+  GCDWS_LOG_DEBUG(@"Did open connection on socket %i", _socket);
   [self _readRequestHeaders];
 }
 
 - (GCDWebServerResponse*)processRequest:(GCDWebServerRequest*)request withBlock:(GCDWebServerProcessBlock)block {
-  LOG_DEBUG(@"Connection on socket %i processing %@ request for \"%@\" (%i bytes body)", _socket, _request.method, _request.path, _request.contentLength);
+  GCDWS_LOG_DEBUG(@"Connection on socket %i processing %@ request for \"%@\" (%i bytes body)", _socket, _request.method, _request.path, _request.contentLength);
   GCDWebServerResponse* response = nil;
   @try {
     response = block(request);
   }
   @catch (NSException* exception) {
-    LOG_EXCEPTION(exception);
+    GCDWS_LOG_EXCEPTION(exception);
   }
   return response;
 }
@@ -494,9 +494,9 @@ static dispatch_queue_t _formatterQueue = NULL;
 - (void)close {
   int result = close(_socket);
   if (result != 0) {
-    LOG_ERROR(@"Failed closing socket %i for connection (%i): %s", _socket, errno, strerror(errno));
+    GCDWS_LOG_ERROR(@"Failed closing socket %i for connection (%i): %s", _socket, errno, strerror(errno));
   }
-  LOG_DEBUG(@"Did close connection on socket %i", _socket);
+  GCDWS_LOG_DEBUG(@"Did close connection on socket %i", _socket);
 }
 
 @end

--- a/CGDWebServer/GCDWebServerPrivate.h
+++ b/CGDWebServer/GCDWebServerPrivate.h
@@ -76,11 +76,11 @@ static inline void __LogMessage(long level, NSString* format, ...) {
   }
 }
 
-#define LOG_VERBOSE(...) __LogMessage(1, __VA_ARGS__)
-#define LOG_INFO(...) __LogMessage(2, __VA_ARGS__)
-#define LOG_WARNING(...) __LogMessage(3, __VA_ARGS__)
-#define LOG_ERROR(...) __LogMessage(4, __VA_ARGS__)
-#define LOG_EXCEPTION(__EXCEPTION__) __LogMessage(5, @"%@", __EXCEPTION__)
+#define GCDWS_LOG_VERBOSE(...) __LogMessage(1, __VA_ARGS__)
+#define GCDWS_LOG_INFO(...) __LogMessage(2, __VA_ARGS__)
+#define GCDWS_LOG_WARNING(...) __LogMessage(3, __VA_ARGS__)
+#define GCDWS_LOG_ERROR(...) __LogMessage(4, __VA_ARGS__)
+#define GCDWS_LOG_EXCEPTION(__EXCEPTION__) __LogMessage(5, @"%@", __EXCEPTION__)
 
 #ifdef NDEBUG
 
@@ -97,7 +97,7 @@ static inline void __LogMessage(long level, NSString* format, ...) {
     } \
   } while (0)
 #define DNOT_REACHED() abort()
-#define LOG_DEBUG(...) __LogMessage(0, __VA_ARGS__)
+#define GCDWS_LOG_DEBUG(...) __LogMessage(0, __VA_ARGS__)
 
 #endif
 


### PR DESCRIPTION
We are using NSLogger and CocoaLumberjack. The Generic `LOG_*` macros were conflicting with the macros in NSLogger. As I suspect that this might happen with other logger macros to, I would suggest prefixing the macros with `GCDWS_`
