### PR TITLE
Fixes a static analyzer warning about unused variables for disabled logging

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -842,33 +842,29 @@ static inline NSString* _EncodeBase64(NSString* string) {
 - (void)logVerbose:(NSString*)format, ... {
   va_list arguments;
   va_start(arguments, format);
-  LOG_VERBOSE(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  LOG_VERBOSE(@"%@", ARC_AUTORELEASE([[NSString alloc] initWithFormat:format arguments:arguments]));
   va_end(arguments);
-  ARC_RELEASE(message);
 }
 
 - (void)logInfo:(NSString*)format, ... {
   va_list arguments;
   va_start(arguments, format);
-  LOG_INFO(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  LOG_INFO(@"%@", ARC_AUTORELEASE([[NSString alloc] initWithFormat:format arguments:arguments]));
   va_end(arguments);
-  ARC_RELEASE(message);
 }
 
 - (void)logWarning:(NSString*)format, ... {
   va_list arguments;
   va_start(arguments, format);
-  LOG_WARNING(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  LOG_WARNING(@"%@", ARC_AUTORELEASE([[NSString alloc] initWithFormat:format arguments:arguments]));
   va_end(arguments);
-  ARC_RELEASE(message);
 }
 
 - (void)logError:(NSString*)format, ... {
   va_list arguments;
   va_start(arguments, format);
-  LOG_ERROR(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  LOG_ERROR(@"%@", ARC_AUTORELEASE([[NSString alloc] initWithFormat:format arguments:arguments]));
   va_end(arguments);
-  ARC_RELEASE(message);
 }
 
 @end


### PR DESCRIPTION
I have fixed the issues with non-ARC settings. Let me know me know if this works for you. 

See #42
