### PR TITLE
Fix GCDWebServerParseURLEncodedForm to allow empty values.

### DIFF
--- a/GCDWebServer/Core/GCDWebServerFunctions.m
+++ b/GCDWebServer/Core/GCDWebServerFunctions.m
@@ -198,8 +198,9 @@ NSDictionary* GCDWebServerParseURLEncodedForm(NSString* form) {
     [scanner setScanLocation:([scanner scanLocation] + 1)];
     
     NSString* value = nil;
-    if (![scanner scanUpToString:@"&" intoString:&value]) {
-      break;
+    [scanner scanUpToString:@"&" intoString:&value];
+    if (value == nil) {
+      value = @"";
     }
     
     key = [key stringByReplacingOccurrencesOfString:@"+" withString:@" "];


### PR DESCRIPTION
If the input string is something like foo=&bar= then both foo and bar
should be in the result, with the empty string as their corresponding value.

The [scanner scanUpToString:@"&" ...] call was returning failure, because
it was already positioned at the &.  In this situation, just set value to the
empty string.
