### PR TITLE
Fix content-types like "application/json; charset=utf-8"

### DIFF
--- a/GCDWebServer/Requests/GCDWebServerDataRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerDataRequest.m
@@ -97,7 +97,8 @@
 
 - (id)jsonObject {
   if (_jsonObject == nil) {
-    if ([self.contentType isEqualToString:@"application/json"] || [self.contentType isEqualToString:@"text/json"] || [self.contentType isEqualToString:@"text/javascript"]) {
+    NSString* mimeType = GCDWebServerTruncateHeaderValue(self.contentType);
+    if ([mimeType isEqualToString:@"application/json"] || [mimeType isEqualToString:@"text/json"] || [mimeType isEqualToString:@"text/javascript"]) {
       _jsonObject = ARC_RETAIN([NSJSONSerialization JSONObjectWithData:_data options:0 error:NULL]);
     } else {
       DNOT_REACHED();


### PR DESCRIPTION
I was getting a crash whenever I tried to use `[GCDWebServerDataRequest jsonObject]` with angular, which would send JSON using the content-type `application/json;charset=UTF-8`. This fix makes that work and should also support the variant with a space (`application/json; charset=utf-8`).
