### PR TITLE
Can specify a custom Bonjour service type for the server.

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -356,18 +356,6 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  */
 - (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name;
 
-/**
- *  Starts the server on a given port and with a specific Bonjour name and type.
- *  Pass a nil Bonjour name to disable Bonjour entirely or an empty string to
- *  use the computer / device name.
- *  Pass a nil or empty string to Bonjour type to use the standard
- *  HTTP web server type "_http._tcp".
- *
- *  Returns NO if the server failed to start.
- */
-- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name bonjourType:(NSString*)bonjourType;
-
-
 #if !TARGET_OS_IPHONE
 
 /**
@@ -380,18 +368,6 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  @warning This method must be used from the main thread only.
  */
 - (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name;
-
-/**
- *  Runs the server synchronously using -startWithPort:bonjourName:bonjourType:
- *  until a SIGINT signal is received i.e. Ctrl-C. This method is intended
- *  to be used by command line tools.
- *
- *  Returns NO if the server failed to start.
- *
- *  @warning This method must be used from the main thread only.
- */
-- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name bonjourType:(NSString*)bonjourType;
-
 
 /**
  *  Runs the server synchronously using -startWithOptions: until a SIGTERM or

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -681,29 +681,18 @@ static inline NSString* _EncodeBase64(NSString* string) {
 }
 
 - (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name {
-  return [self startWithPort:port bonjourName:name bonjourType:nil];
-}
-
-- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name bonjourType:(NSString *)bonjourType {
   NSMutableDictionary* options = [NSMutableDictionary dictionary];
   [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
   [options setValue:name forKey:GCDWebServerOption_BonjourName];
-  if (bonjourType.length) { [options setObject:bonjourType forKey:GCDWebServerOption_BonjourType]; }
   return [self startWithOptions:options error:NULL];
 }
 
 #if !TARGET_OS_IPHONE
 
-- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name
-{
-  return [self runWithPort:port bonjourName:name bonjourType:nil];
-}
-
-- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name bonjourType:(NSString*)bonjourType {
+- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name {
   NSMutableDictionary* options = [NSMutableDictionary dictionary];
   [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
   [options setValue:name forKey:GCDWebServerOption_BonjourName];
-  if (bonjourType.length) { [options setObject:bonjourType forKey:GCDWebServerOption_BonjourType]; }
   return [self runWithOptions:options error:NULL];
 }
 


### PR DESCRIPTION
This PR adds a feature to be able to specify a custom Bonjour type for the server, instead of being hardcoded to the standard `_http._tcp`. Existing API-s do not change and continue to work as before, new API-s added to specify the custom type.
