### PR TITLE
fix memory leak in _writeData method

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -268,7 +268,7 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
     }
     
   });
-  ARC_DISPATCH_RELEASE(buffer);
+  dispatch_release(buffer);
 }
 
 - (void)_writeHeadersWithCompletionBlock:(WriteHeadersCompletionBlock)block {


### PR DESCRIPTION
App should release dispatch_data_t if it creates if by dispatch_data_create with non-default destructor. As far as I understand ARC_DISPATCH_RELEASE was created for managing dispatch_queue_t and it's correct. But ARC won't manage dispatch_data_t.
