### PR TITLE
[FIX] Check that the CFBundleDisplayName is not nil

### DIFF
--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -347,6 +347,9 @@
       NSString* footer = server.footer;
       if (footer == nil) {
         NSString* name = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        if (name == nil) {
+          name = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        }
         NSString* version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 #if !TARGET_OS_IPHONE
         if (!name && !version) {


### PR DESCRIPTION
With Xcode 6, when you create a new project the `CFBundleDisplayName` is not filled by default, so when you use the `GCDWebUploader` class it crashes because of a value of the array is nil

To fix that I just check whether the `CFBundleDisplayName` is present and if not I uses the `CFBundleName`
