### PR TITLE
Avoid potential null dereference with NSError

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -536,21 +536,21 @@ static inline NSString* _EncodeBase64(NSString* string) {
           });
         }
       } else {
-        if (error) {
+        if (error != NULL) {
           *error = GCDWebServerMakePosixError(errno);
         }
         LOG_ERROR(@"Failed starting listening socket: %s (%i)", strerror(errno), errno);
         close(listeningSocket);
       }
     } else {
-      if (error) {
+      if (error != NULL) {
         *error = GCDWebServerMakePosixError(errno);
       }
       LOG_ERROR(@"Failed binding listening socket: %s (%i)", strerror(errno), errno);
       close(listeningSocket);
     }
   } else {
-    if (error) {
+    if (error != NULL) {
       *error = GCDWebServerMakePosixError(errno);
     }
     LOG_ERROR(@"Failed creating listening socket: %s (%i)", strerror(errno), errno);

--- a/GCDWebServer/Core/GCDWebServerRequest.m
+++ b/GCDWebServer/Core/GCDWebServerRequest.m
@@ -84,7 +84,9 @@ NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
 - (BOOL)open:(NSError**)error {
   int result = inflateInit2(&_stream, 15 + 16);
   if (result != Z_OK) {
-    *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+    if (error != NULL) {
+      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+    }
     return NO;
   }
   if (![super open:error]) {
@@ -111,7 +113,9 @@ NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
     int result = inflate(&_stream, Z_NO_FLUSH);
     if ((result != Z_OK) && (result != Z_STREAM_END)) {
       ARC_RELEASE(decodedData);
-      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+      if (error != NULL) {
+        *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+      }
       return NO;
     }
     length += maxLength - _stream.avail_out;

--- a/GCDWebServer/Core/GCDWebServerResponse.m
+++ b/GCDWebServer/Core/GCDWebServerResponse.m
@@ -90,7 +90,9 @@
 - (BOOL)open:(NSError**)error {
   int result = deflateInit2(&_stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
   if (result != Z_OK) {
-    *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+    if (error != NULL) {
+      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+    }
     return NO;
   }
   if (![super open:error]) {
@@ -127,7 +129,9 @@
           _finished = YES;
         } else if (result != Z_OK) {
           ARC_RELEASE(encodedData);
-          *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+          if (error != NULL) {
+            *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+          }
           return nil;
         }
         length += maxLength - _stream.avail_out;

--- a/GCDWebServer/Requests/GCDWebServerDataRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerDataRequest.m
@@ -55,7 +55,9 @@
     _data = [[NSMutableData alloc] init];
   }
   if (_data == nil) {
-    *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed allocating memory"}];
+    if (error != NULL) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed allocating memory"}];
+    }
     return NO;
   }
   return YES;

--- a/GCDWebServer/Requests/GCDWebServerFileRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerFileRequest.m
@@ -55,7 +55,9 @@
 - (BOOL)open:(NSError**)error {
   _file = open([_temporaryPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   if (_file <= 0) {
-    *error = GCDWebServerMakePosixError(errno);
+    if (error != NULL) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
     return NO;
   }
   return YES;
@@ -63,7 +65,9 @@
 
 - (BOOL)writeData:(NSData*)data error:(NSError**)error {
   if (write(_file, data.bytes, data.length) != (ssize_t)data.length) {
-    *error = GCDWebServerMakePosixError(errno);
+    if (error != NULL) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
     return NO;
   }
   return YES;
@@ -71,7 +75,9 @@
 
 - (BOOL)close:(NSError**)error {
   if (close(_file) < 0) {
-    *error = GCDWebServerMakePosixError(errno);
+    if (error != NULL) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
     return NO;
   }
 #ifdef __GCDWEBSERVER_ENABLE_TESTING__

--- a/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
@@ -432,7 +432,9 @@ static NSData* _dashNewlineData = nil;
 
 - (BOOL)writeData:(NSData*)data error:(NSError**)error {
   if (![_parser appendBytes:data.bytes length:data.length]) {
-    *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed continuing to parse multipart form data"}];
+    if (error != NULL) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed continuing to parse multipart form data"}];
+    }
     return NO;
   }
   return YES;
@@ -443,7 +445,9 @@ static NSData* _dashNewlineData = nil;
   ARC_RELEASE(_parser);
   _parser = nil;
   if (!atEnd) {
-    *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed finishing to parse multipart form data"}];
+    if (error != NULL) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Failed finishing to parse multipart form data"}];
+    }
     return NO;
   }
   return YES;

--- a/GCDWebServer/Responses/GCDWebServerFileResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerFileResponse.m
@@ -148,11 +148,15 @@ static inline NSDate* _NSDateFromTimeSpec(const struct timespec* t) {
 - (BOOL)open:(NSError**)error {
   _file = open([_path fileSystemRepresentation], O_NOFOLLOW | O_RDONLY);
   if (_file <= 0) {
-    *error = GCDWebServerMakePosixError(errno);
+    if (error != NULL) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
     return NO;
   }
   if (lseek(_file, _offset, SEEK_SET) != (off_t)_offset) {
-    *error = GCDWebServerMakePosixError(errno);
+    if (error != NULL) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
     close(_file);
     return NO;
   }
@@ -164,7 +168,9 @@ static inline NSDate* _NSDateFromTimeSpec(const struct timespec* t) {
   NSMutableData* data = [[NSMutableData alloc] initWithLength:length];
   ssize_t result = read(_file, data.mutableBytes, length);
   if (result < 0) {
-    *error = GCDWebServerMakePosixError(errno);
+    if (error != NULL) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
     return nil;
   }
   if (result > 0) {


### PR DESCRIPTION
Potential null dereference.  According to coding standards in 'Creating and Returning NSError Objects' the parameter may be null.

I've added checks for `if (error != NULL)`. I believe `if (error)` would work to, but I feel explicitly checking `NULL`  explains the intention better. If you disagree I will amend the pull request to use `if (error)`.
