### PR TITLE
fallback to locahost if the wifi is not available

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -679,7 +679,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
 
 - (NSURL*)serverURL {
   if (_source) {
-    NSString* ipAddress = GCDWebServerGetPrimaryIPv4Address();
+    NSString* ipAddress = GCDWebServerGetPrimaryIPv4Address() ?: @"127.0.0.1";
     if (ipAddress) {
       if (_port != 80) {
         return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", ipAddress, (int)_port]];


### PR DESCRIPTION
If the wifi is not available (airplane mode) the web server will not return the URL. 

My app uses your server as a proxy, so it needs to communicate with the server also when the wi-fi is not available. This fix will make the server to fallback to localhost. 
