### PR TITLE
Dispatch to main thread if the initialize method is called from another thread

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -188,7 +188,14 @@ static void _ExecuteMainThreadRunLoopSources() {
             shouldAutomaticallyMapHEADToGET=_mapHEADToGET;
 
 + (void)initialize {
-  GCDWebServerInitializeFunctions();
+    if ([NSThread isMainThread]) {
+        GCDWebServerInitializeFunctions();
+    }
+    else {
+        dispatch_async(dispatch_get_main_queue(), ^(void){
+            GCDWebServerInitializeFunctions();
+        });
+    }
 }
 
 - (instancetype)init {


### PR DESCRIPTION
Hi swisspool,

When I include both GCDWebServer and Crittercism libraries in the same app, the GWS_DCHECK([NSThread isMainThread]) makes the app to crash. The problem is that Crittercism does some runtime magic when it's initialized and therefore [GCDWebServer Initialize] method is called from another thread before I really want to use it or create any instance.

I have changed the initialize method to dispatch the GCDWebServerInitializeFunctions call to the main thread if required. This fixes the crash with Crittercism and keeps the default behaviour when the initialize is called from the main thread.

By the way, awesome library ;)
