### PR TITLE
Added GCDWebServerAsyncPushResponse response type

### DIFF
--- a/GCDWebServer.xcodeproj/project.pbxproj
+++ b/GCDWebServer.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		2B07616C1A57CE960011E8F3 /* GCDWebServerAsyncPushResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B07616B1A57CE960011E8F3 /* GCDWebServerAsyncPushResponse.m */; };
 		E208D149167B76B700500836 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E208D148167B76B700500836 /* CFNetwork.framework */; };
 		E208D1B3167BB17E00500836 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E208D1B2167BB17E00500836 /* CoreServices.framework */; };
 		E221128F1690B6470048D2B2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E221128E1690B6470048D2B2 /* main.m */; };
@@ -100,11 +101,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2B07616A1A57CB910011E8F3 /* GCDWebServerAsyncPushResponse.h */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = GCDWebServerAsyncPushResponse.h; sourceTree = "<group>"; tabWidth = 2; };
+		2B07616B1A57CE960011E8F3 /* GCDWebServerAsyncPushResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = GCDWebServerAsyncPushResponse.m; sourceTree = "<group>"; tabWidth = 2; };
 		8DD76FB20486AB0100D96B5E /* GCDWebServer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = GCDWebServer; sourceTree = BUILT_PRODUCTS_DIR; };
 		E208D148167B76B700500836 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		E208D1B2167BB17E00500836 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 		E221125A1690B4DE0048D2B2 /* GCDWebServer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GCDWebServer.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E221128E1690B6470048D2B2 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		E221128E1690B6470048D2B2 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; tabWidth = 2; };
 		E22112911690B64F0048D2B2 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		E22112921690B64F0048D2B2 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		E22112931690B64F0048D2B2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -306,6 +309,8 @@
 				E28BAE3118F99C810095C089 /* GCDWebServerFileResponse.m */,
 				E28BAE3218F99C810095C089 /* GCDWebServerStreamedResponse.h */,
 				E28BAE3318F99C810095C089 /* GCDWebServerStreamedResponse.m */,
+				2B07616A1A57CB910011E8F3 /* GCDWebServerAsyncPushResponse.h */,
+				2B07616B1A57CE960011E8F3 /* GCDWebServerAsyncPushResponse.m */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -433,6 +438,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E28BAE4618F99C810095C089 /* GCDWebServerDataResponse.m in Sources */,
+				2B07616C1A57CE960011E8F3 /* GCDWebServerAsyncPushResponse.m in Sources */,
 				E28BAE3818F99C810095C089 /* GCDWebServerFunctions.m in Sources */,
 				E28BAE4A18F99C810095C089 /* GCDWebServerFileResponse.m in Sources */,
 				E28BAE4418F99C810095C089 /* GCDWebServerURLEncodedFormRequest.m in Sources */,

--- a/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -47,6 +47,7 @@
 #import "GCDWebServerErrorResponse.h"
 #import "GCDWebServerFileResponse.h"
 #import "GCDWebServerStreamedResponse.h"
+#import "GCDWebServerAsyncPushResponse.h"
 
 /**
  *  Check if a custom logging facility should be used instead.

--- a/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.h
@@ -51,6 +51,6 @@
  *  And this method is called to signal completion
  *  Pass nil for the error if there are no problems
 */
-- (void)completeWithErorr:(NSError*)error;
+- (void)completeWithError:(NSError*)error;
 
 @end

--- a/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.h
@@ -1,0 +1,56 @@
+/*
+ Copyright (c) 2012-2014, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerResponse.h"
+
+/**
+ *  This response type lets you push data into it asynchronously
+ *  and have it end up on the connection, as opposed to GCDWebServerStreamedResponse
+ *  which requires you to provide data when asked
+*/
+@interface GCDWebServerAsyncPushResponse : GCDWebServerResponse
+
+/**
+ *  The designated initialiser for the class
+*/
+- (instancetype)initWithContentType:(NSString*)type;
+
+/**
+ *  This method is the way you push data into the response
+ *  Unlike the other response types, calling it with empty data
+ *  does nothing special; call the completeWithError: selector
+ *  to signal completion
+*/
+- (void)sendWithData:(NSData*)data;
+
+/**
+ *  And this method is called to signal completion
+ *  Pass nil for the error if there are no problems
+*/
+- (void)completeWithErorr:(NSError*)error;
+
+@end

--- a/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.m
@@ -1,0 +1,110 @@
+/*
+ Copyright (c) 2012-2014, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@interface GCDWebServerAsyncPushResponse () {
+@private
+  NSMutableData* _buffer;
+  GCDWebServerBodyReaderCompletionBlock _pendingReadBlock;
+  NSError* _pendingError;
+  BOOL _haveFinished;
+}
+@end
+
+@implementation GCDWebServerAsyncPushResponse
+
+- (instancetype)initWithContentType:(NSString *)type {
+  if ((self = [super init])) {
+    self.contentType = type;
+    _buffer = [[NSMutableData alloc] init];
+    
+    _haveFinished = NO;
+    _pendingError = nil;
+    _pendingReadBlock = nil;
+  }
+  
+  return self;
+}
+
+- (void)asyncReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block {
+  //The server has asked us for data
+  //Provide the contents of the buffer if we can, otherwise defer providing the server
+  //data until later
+  @synchronized(_buffer) {
+    if (_pendingError != nil) {
+      //Case #1: we have a problem
+      block(nil, _pendingError);
+      _pendingReadBlock = nil;
+      
+    } else if (_buffer.length > 0){
+      //Case #2: we have data
+      block([_buffer copy], nil);
+      _buffer.length = 0; //clear the buffer
+      _pendingReadBlock = nil;
+      
+    } else if (_haveFinished == YES) {
+      //Case #3: we are done, and the buffer is now empty
+      block([[NSData alloc] init], nil);
+      _pendingReadBlock = nil;
+      
+    } else {
+      //Case #4: we have none of these things; deferr our response until later
+      _pendingReadBlock = block;
+    }
+  }
+}
+
+- (void)pumpPendingRead {
+  if (_pendingReadBlock != nil) {
+    [self asyncReadDataWithCompletion:_pendingReadBlock];
+  }
+}
+
+- (void)sendWithData:(NSData *)data {
+  @synchronized(_buffer) {
+    [_buffer appendData:data];
+    [self pumpPendingRead];
+  }
+}
+
+- (void)completeWithErorr:(NSError *)error {
+  @synchronized(_buffer) {
+    if (error == nil) {
+      _haveFinished = YES;
+    } else {
+      _pendingError = error;
+    }
+    [self pumpPendingRead];
+  }
+}
+
+@end

--- a/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.m
@@ -29,7 +29,7 @@
 #error GCDWebServer requires ARC
 #endif
 
-#import "GCDWebServerPrivate.h"
+#import "GCDWebServerAsyncPushResponse.h"
 
 @interface GCDWebServerAsyncPushResponse () {
 @private

--- a/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerAsyncPushResponse.m
@@ -105,7 +105,7 @@
   });
 }
 
-- (void)completeWithErorr:(NSError *)error {
+- (void)completeWithError:(NSError *)error {
   dispatch_sync(_serialQueue, ^{
     if (error == nil) {
       _haveFinished = YES;

--- a/Mac/main.m
+++ b/Mac/main.m
@@ -421,7 +421,7 @@ int main(int argc, const char* argv[]) {
                            [response sendWithData:world];
                            dispatch_after(oneSecond, queue, ^{
                              [response sendWithData:fromPush];
-                             [response completeWithErorr:nil];
+                             [response completeWithError:nil];
                            });
                          });
                          

--- a/Mac/main.m
+++ b/Mac/main.m
@@ -35,6 +35,7 @@
 
 #import "GCDWebServerDataResponse.h"
 #import "GCDWebServerStreamedResponse.h"
+#import "GCDWebServerAsyncPushResponse.h"
 
 #import "GCDWebDAVServer.h"
 
@@ -53,7 +54,8 @@ typedef enum {
   kMode_WebUploader,
   kMode_StreamingResponse,
   kMode_AsyncResponse,
-  kMode_AsyncResponse2
+  kMode_AsyncResponse2,
+  kMode_AsyncPushResponse
 } Mode;
 
 @interface Delegate : NSObject <GCDWebServerDelegate, GCDWebDAVServerDelegate, GCDWebUploaderDelegate>
@@ -145,7 +147,7 @@ int main(int argc, const char* argv[]) {
     BOOL bindToLocalhost = NO;
     
     if (argc == 1) {
-      fprintf(stdout, "Usage: %s [-mode webServer | htmlPage | htmlForm | htmlFileUpload | webDAV | webUploader | streamingResponse | asyncResponse | asyncResponse2] [-record] [-root directory] [-tests directory] [-authenticationMethod Basic | Digest] [-authenticationRealm realm] [-authenticationUser user] [-authenticationPassword password] [--localhost]\n\n", basename((char*)argv[0]));
+      fprintf(stdout, "Usage: %s [-mode webServer | htmlPage | htmlForm | htmlFileUpload | webDAV | webUploader | streamingResponse | asyncResponse | asyncResponse2 | asyncPushResponse] [-record] [-root directory] [-tests directory] [-authenticationMethod Basic | Digest] [-authenticationRealm realm] [-authenticationUser user] [-authenticationPassword password] [--localhost]\n\n", basename((char*)argv[0]));
     } else {
       for (int i = 1; i < argc; ++i) {
         if (argv[i][0] != '-') {
@@ -171,6 +173,8 @@ int main(int argc, const char* argv[]) {
             mode = kMode_AsyncResponse;
           } else if (!strcmp(argv[i], "asyncResponse2")) {
             mode = kMode_AsyncResponse2;
+          } else if (!strcmp(argv[i], "asyncPushResponse")) {
+            mode = kMode_AsyncPushResponse;
           }
         } else if (!strcmp(argv[i], "-record")) {
           recording = YES;
@@ -401,6 +405,42 @@ int main(int argc, const char* argv[]) {
           
         }];
         break;
+      }
+      case kMode_AsyncPushResponse: {
+        fprintf(stdout, "Running in Async Push Response mode");
+        
+        //The data we're going to send
+        NSData* hello = [@"hello" dataUsingEncoding:NSUTF8StringEncoding];
+        NSData* world = [@" world" dataUsingEncoding:NSUTF8StringEncoding];
+        NSData* fromPush = [@" from push" dataUsingEncoding:NSUTF8StringEncoding];
+        
+        dispatch_time_t oneSecond = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC));
+        dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+        
+        webServer = [[GCDWebServer alloc] init];
+        [webServer addHandlerForMethod:@"GET"
+                                  path:@"/"
+                          requestClass:[GCDWebServerRequest class]
+                     asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock handlerCompletionBlock) {
+        
+                       dispatch_after(oneSecond, queue, ^{
+                         GCDWebServerAsyncPushResponse* response = [[GCDWebServerAsyncPushResponse alloc] initWithContentType:@"text/plain"];
+                         [response sendWithData:hello];
+                         
+                         dispatch_after(oneSecond, queue, ^{
+                           [response sendWithData:world];
+                           dispatch_after(oneSecond, queue, ^{
+                             [response sendWithData:fromPush];
+                             [response completeWithErorr:nil];
+                           });
+                         });
+                         
+                         handlerCompletionBlock(response);
+                       });
+                       
+        }];
+        break;
+
       }
       
     }


### PR DESCRIPTION
Continuing on from the discussion in #118 

In my project, I am implementing a proxy server which takes all requests, replays them to a remote server, and streams the response back to the original requester in my app. This PR adds a kind of buffered responder which you can push data into as you like, providing data to the web server when the appropriate dataReader callbacks are made. Hopefully this should address your concerns about choosing the right time to pass off the data to the  kernel.

I think this would be a good inclusion in the main project because other people doing similar things might find this mode of operation useful, but there is nothing special about this that requires it be in the GCDWebServerTree; I could easily just drop this code into my own project. 

What are your feelings about this kind of response type?