### PR TITLE
Expose the connection that owns a request

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -40,7 +40,7 @@
  *  GCDWebServerRequest instance created with the same basic info.
  *  Otherwise, it simply returns nil.
  */
-typedef GCDWebServerRequest* (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery);
+typedef GCDWebServerRequest* (^GCDWebServerMatchBlock)(GCDWebServerConnection *connection, NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery);
 
 /**
  *  The GCDWebServerProcessBlock is called after the HTTP request has been fully

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -796,12 +796,12 @@ static inline NSString* _EncodeBase64(NSString* string) {
 }
 
 - (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
-  [self addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
+  [self addHandlerWithMatchBlock:^GCDWebServerRequest *(GCDWebServerConnection *connection, NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
     
     if (![requestMethod isEqualToString:method]) {
       return nil;
     }
-    return [[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+    return [[aClass alloc] initWithConnection:connection method:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
     
   } asyncProcessBlock:block];
 }
@@ -814,7 +814,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
 
 - (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
   if ([path hasPrefix:@"/"] && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
-    [self addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
+    [self addHandlerWithMatchBlock:^GCDWebServerRequest *(GCDWebServerConnection *connection, NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
       
       if (![requestMethod isEqualToString:method]) {
         return nil;
@@ -822,7 +822,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
       if ([urlPath caseInsensitiveCompare:path] != NSOrderedSame) {
         return nil;
       }
-      return [[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+      return [[aClass alloc] initWithConnection:connection method:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
       
     } asyncProcessBlock:block];
   } else {
@@ -839,7 +839,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
 - (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
   NSRegularExpression* expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:NULL];
   if (expression && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
-    [self addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
+    [self addHandlerWithMatchBlock:^GCDWebServerRequest *(GCDWebServerConnection *connection, NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
       
       if (![requestMethod isEqualToString:method]) {
         return nil;
@@ -858,7 +858,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
         }
       }
 
-      GCDWebServerRequest* request = [[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+      GCDWebServerRequest* request = [[aClass alloc] initWithConnection:connection method:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
       [request setAttribute:captures forKey:GCDWebServerRequestAttribute_RegexCaptures];
       return request;
       
@@ -928,7 +928,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
 - (void)addGETHandlerForBasePath:(NSString*)basePath directoryPath:(NSString*)directoryPath indexFilename:(NSString*)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
   if ([basePath hasPrefix:@"/"] && [basePath hasSuffix:@"/"]) {
     GCDWebServer* __unsafe_unretained server = self;
-    [self addHandlerWithMatchBlock:^GCDWebServerRequest *(NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
+    [self addHandlerWithMatchBlock:^GCDWebServerRequest *(GCDWebServerConnection *connection,  NSString* requestMethod, NSURL* requestURL, NSDictionary* requestHeaders, NSString* urlPath, NSDictionary* urlQuery) {
       
       if (![requestMethod isEqualToString:@"GET"]) {
         return nil;
@@ -936,7 +936,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
       if (![urlPath hasPrefix:basePath]) {
         return nil;
       }
-      return [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+      return [[GCDWebServerRequest alloc] initWithConnection:connection method:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
       
     } processBlock:^GCDWebServerResponse *(GCDWebServerRequest* request) {
       

--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -542,7 +542,7 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
       NSDictionary* requestQuery = queryString ? GCDWebServerParseURLEncodedForm(queryString) : @{};
       if (requestMethod && requestURL && requestHeaders && requestPath && requestQuery) {
         for (_handler in _server.handlers) {
-          _request = _handler.matchBlock(requestMethod, requestURL, requestHeaders, requestPath, requestQuery);
+          _request = _handler.matchBlock(self, requestMethod, requestURL, requestHeaders, requestPath, requestQuery);
           if (_request) {
             break;
           }
@@ -584,7 +584,7 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
             [self _startProcessingRequest];
           }
         } else {
-          _request = [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:requestPath query:requestQuery];
+          _request = [[GCDWebServerRequest alloc] initWithConnection:self method:requestMethod url:requestURL headers:requestHeaders path:requestPath query:requestQuery];
           GWS_DCHECK(_request);
           [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_MethodNotAllowed];
         }

--- a/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/GCDWebServer/Core/GCDWebServerRequest.h
@@ -27,6 +27,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class GCDWebServerConnection;
+
 /**
  *  Attribute key to retrieve an NSArray containing NSStrings from a GCDWebServerRequest
  *  with the contents of any regular expression captures done on the request path.
@@ -86,6 +88,11 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *  @warning GCDWebServerRequest instances can be created and used on any GCD thread.
  */
 @interface GCDWebServerRequest : NSObject <GCDWebServerBodyWriter>
+
+/**
+ *  Returns the GCDWebServerConnection that owns the request.
+ */
+@property(nonatomic, weak, readonly) GCDWebServerConnection* connection;
 
 /**
  *  Returns the HTTP method for the request.
@@ -160,7 +167,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
 /**
  *  This method is the designated initializer for the class.
  */
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query;
+- (instancetype)initWithConnection:(GCDWebServerConnection*)connection method:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query;
 
 /**
  *  Convenience method that checks if the contentType property is defined.

--- a/GCDWebServer/Core/GCDWebServerRequest.m
+++ b/GCDWebServer/Core/GCDWebServerRequest.m
@@ -170,8 +170,9 @@ NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
 @synthesize method=_method, URL=_url, headers=_headers, path=_path, query=_query, contentType=_type, contentLength=_length, ifModifiedSince=_modifiedSince, ifNoneMatch=_noneMatch,
             byteRange=_range, acceptsGzipContentEncoding=_gzipAccepted, usesChunkedTransferEncoding=_chunked;
 
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query {
+- (instancetype)initWithConnection:(GCDWebServerConnection*)connection method:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query {
   if ((self = [super init])) {
+    _connection = connection;
     _method = [method copy];
     _url = url;
     _headers = headers;

--- a/GCDWebServer/Requests/GCDWebServerFileRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerFileRequest.m
@@ -42,8 +42,8 @@
 
 @synthesize temporaryPath=_temporaryPath;
 
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query {
-  if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
+- (instancetype)initWithConnection:(GCDWebServerConnection *)connection method:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query {
+  if ((self = [super initWithConnection:connection method:method url:url headers:headers path:path query:query])) {
     _temporaryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
   }
   return self;

--- a/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
+++ b/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
@@ -364,8 +364,8 @@ static NSData* _dashNewlineData = nil;
   return @"multipart/form-data";
 }
 
-- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query {
-  if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
+- (instancetype)initWithConnection:(GCDWebServerConnection *)connection method:(NSString*)method url:(NSURL*)url headers:(NSDictionary*)headers path:(NSString*)path query:(NSDictionary*)query {
+    if ((self = [super initWithConnection:connection method:method url:url headers:headers path:path query:query])) {
     _arguments = [[NSMutableArray alloc] init];
     _files = [[NSMutableArray alloc] init];
   }


### PR DESCRIPTION
In my app I need the address of the sender of the request but that's accessible only through the connection instance which isn't accessible.

I doubted between injecting only the remoteAddress or exposing the whole connection, and I chose the second because it's consistent with the connections exposing the server they belong to.