### PR TITLE
Added standalone Mac OS X framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ xcuserdata
 project.xcworkspace
 
 Tests/Payload
+Build

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ xcuserdata
 project.xcworkspace
 
 Tests/Payload
-Build

--- a/GCDWebServer.xcodeproj/project.pbxproj
+++ b/GCDWebServer.xcodeproj/project.pbxproj
@@ -22,6 +22,35 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		BF933FF31AD3C72400E78E05 /* GCDWebServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE1618F99C810095C089 /* GCDWebServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF933FF41AD3C72400E78E05 /* GCDWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE1718F99C810095C089 /* GCDWebServer.m */; };
+		BF933FF51AD3C72400E78E05 /* GCDWebServerConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE1818F99C810095C089 /* GCDWebServerConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF933FF61AD3C72400E78E05 /* GCDWebServerConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE1918F99C810095C089 /* GCDWebServerConnection.m */; };
+		BF933FF71AD3C72400E78E05 /* GCDWebServerFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE1A18F99C810095C089 /* GCDWebServerFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF933FF81AD3C72400E78E05 /* GCDWebServerFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE1B18F99C810095C089 /* GCDWebServerFunctions.m */; };
+		BF933FF91AD3C72400E78E05 /* GCDWebServerHTTPStatusCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE1C18F99C810095C089 /* GCDWebServerHTTPStatusCodes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF933FFA1AD3C72400E78E05 /* GCDWebServerPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE1D18F99C810095C089 /* GCDWebServerPrivate.h */; };
+		BF933FFB1AD3C72400E78E05 /* GCDWebServerRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE1E18F99C810095C089 /* GCDWebServerRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF933FFC1AD3C72400E78E05 /* GCDWebServerRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE1F18F99C810095C089 /* GCDWebServerRequest.m */; };
+		BF933FFD1AD3C72400E78E05 /* GCDWebServerResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2018F99C810095C089 /* GCDWebServerResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF933FFE1AD3C72400E78E05 /* GCDWebServerResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2118F99C810095C089 /* GCDWebServerResponse.m */; };
+		BF933FFF1AD3C73500E78E05 /* GCDWebServerDataRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2318F99C810095C089 /* GCDWebServerDataRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF9340001AD3C73500E78E05 /* GCDWebServerDataRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2418F99C810095C089 /* GCDWebServerDataRequest.m */; };
+		BF9340011AD3C73500E78E05 /* GCDWebServerFileRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2518F99C810095C089 /* GCDWebServerFileRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF9340021AD3C73500E78E05 /* GCDWebServerFileRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2618F99C810095C089 /* GCDWebServerFileRequest.m */; };
+		BF9340031AD3C73500E78E05 /* GCDWebServerMultiPartFormRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2718F99C810095C089 /* GCDWebServerMultiPartFormRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF9340041AD3C73500E78E05 /* GCDWebServerMultiPartFormRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2818F99C810095C089 /* GCDWebServerMultiPartFormRequest.m */; };
+		BF9340051AD3C73500E78E05 /* GCDWebServerURLEncodedFormRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2918F99C810095C089 /* GCDWebServerURLEncodedFormRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF9340061AD3C73500E78E05 /* GCDWebServerURLEncodedFormRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2A18F99C810095C089 /* GCDWebServerURLEncodedFormRequest.m */; };
+		BF9340071AD3C74300E78E05 /* GCDWebServerDataResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2C18F99C810095C089 /* GCDWebServerDataResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF9340081AD3C74300E78E05 /* GCDWebServerDataResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2D18F99C810095C089 /* GCDWebServerDataResponse.m */; };
+		BF9340091AD3C74300E78E05 /* GCDWebServerErrorResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE2E18F99C810095C089 /* GCDWebServerErrorResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF93400A1AD3C74300E78E05 /* GCDWebServerErrorResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE2F18F99C810095C089 /* GCDWebServerErrorResponse.m */; };
+		BF93400B1AD3C74300E78E05 /* GCDWebServerFileResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE3018F99C810095C089 /* GCDWebServerFileResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF93400C1AD3C74300E78E05 /* GCDWebServerFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE3118F99C810095C089 /* GCDWebServerFileResponse.m */; };
+		BF93400D1AD3C74300E78E05 /* GCDWebServerStreamedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E28BAE3218F99C810095C089 /* GCDWebServerStreamedResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF93400E1AD3C74300E78E05 /* GCDWebServerStreamedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E28BAE3318F99C810095C089 /* GCDWebServerStreamedResponse.m */; };
+		BF9340141AD3C7B800E78E05 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E2B0D4A618F13495009A7927 /* libz.dylib */; };
 		E208D149167B76B700500836 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E208D148167B76B700500836 /* CFNetwork.framework */; };
 		E208D1B3167BB17E00500836 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E208D1B2167BB17E00500836 /* CoreServices.framework */; };
 		E221128F1690B6470048D2B2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E221128E1690B6470048D2B2 /* main.m */; };
@@ -101,6 +130,8 @@
 
 /* Begin PBXFileReference section */
 		8DD76FB20486AB0100D96B5E /* GCDWebServer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = GCDWebServer; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF933FDA1AD3C65F00E78E05 /* GCDWebServer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GCDWebServer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF933FDD1AD3C65F00E78E05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E208D148167B76B700500836 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		E208D1B2167BB17E00500836 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 		E221125A1690B4DE0048D2B2 /* GCDWebServer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GCDWebServer.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -167,6 +198,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BF933FD61AD3C65F00E78E05 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9340141AD3C7B800E78E05 /* libz.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E22112571690B4DE0048D2B2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -188,6 +227,7 @@
 				E26DC18819E84BC000C68DDC /* README.md */,
 				E26DC18719E84B2200C68DDC /* GCDWebServer.podspec */,
 				E28BAE1418F99C810095C089 /* GCDWebServer */,
+				BF933FDB1AD3C65F00E78E05 /* GCDWebServer.framework */,
 				E2A0E80718F3432600C580B1 /* GCDWebDAVServer */,
 				E2BE850618E77ECA0061360B /* GCDWebUploader */,
 				E221128D1690B6470048D2B2 /* Mac */,
@@ -204,8 +244,18 @@
 			children = (
 				8DD76FB20486AB0100D96B5E /* GCDWebServer */,
 				E221125A1690B4DE0048D2B2 /* GCDWebServer.app */,
+				BF933FDA1AD3C65F00E78E05 /* GCDWebServer.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		BF933FDB1AD3C65F00E78E05 /* GCDWebServer.framework */ = {
+			isa = PBXGroup;
+			children = (
+				BF933FDD1AD3C65F00E78E05 /* Info.plist */,
+			);
+			name = GCDWebServer.framework;
+			path = GCDWebServer;
 			sourceTree = "<group>";
 		};
 		E221128D1690B6470048D2B2 /* Mac */ = {
@@ -331,6 +381,31 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		BF933FD71AD3C65F00E78E05 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF933FF91AD3C72400E78E05 /* GCDWebServerHTTPStatusCodes.h in Headers */,
+				BF933FFB1AD3C72400E78E05 /* GCDWebServerRequest.h in Headers */,
+				BF933FF31AD3C72400E78E05 /* GCDWebServer.h in Headers */,
+				BF9340091AD3C74300E78E05 /* GCDWebServerErrorResponse.h in Headers */,
+				BF9340051AD3C73500E78E05 /* GCDWebServerURLEncodedFormRequest.h in Headers */,
+				BF933FFD1AD3C72400E78E05 /* GCDWebServerResponse.h in Headers */,
+				BF93400B1AD3C74300E78E05 /* GCDWebServerFileResponse.h in Headers */,
+				BF9340031AD3C73500E78E05 /* GCDWebServerMultiPartFormRequest.h in Headers */,
+				BF93400D1AD3C74300E78E05 /* GCDWebServerStreamedResponse.h in Headers */,
+				BF933FF51AD3C72400E78E05 /* GCDWebServerConnection.h in Headers */,
+				BF933FFF1AD3C73500E78E05 /* GCDWebServerDataRequest.h in Headers */,
+				BF9340071AD3C74300E78E05 /* GCDWebServerDataResponse.h in Headers */,
+				BF933FFA1AD3C72400E78E05 /* GCDWebServerPrivate.h in Headers */,
+				BF933FF71AD3C72400E78E05 /* GCDWebServerFunctions.h in Headers */,
+				BF9340011AD3C73500E78E05 /* GCDWebServerFileRequest.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		8DD76FA90486AB0100D96B5E /* GCDWebServer (Mac) */ = {
 			isa = PBXNativeTarget;
@@ -350,6 +425,24 @@
 			productName = LittleCMS;
 			productReference = 8DD76FB20486AB0100D96B5E /* GCDWebServer */;
 			productType = "com.apple.product-type.tool";
+		};
+		BF933FD91AD3C65F00E78E05 /* GCDWebServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF933FF11AD3C66000E78E05 /* Build configuration list for PBXNativeTarget "GCDWebServer" */;
+			buildPhases = (
+				BF933FD51AD3C65F00E78E05 /* Sources */,
+				BF933FD61AD3C65F00E78E05 /* Frameworks */,
+				BF933FD71AD3C65F00E78E05 /* Headers */,
+				BF933FD81AD3C65F00E78E05 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GCDWebServer;
+			productName = GCDWebServer;
+			productReference = BF933FDA1AD3C65F00E78E05 /* GCDWebServer.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		E22112591690B4DE0048D2B2 /* GCDWebServer (iOS) */ = {
 			isa = PBXNativeTarget;
@@ -375,6 +468,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0610;
+				TargetAttributes = {
+					BF933FD91AD3C65F00E78E05 = {
+						CreatedOnToolsVersion = 6.3;
+					};
+				};
 			};
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "GCDWebServer" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -394,11 +492,19 @@
 				E274F876187E77D8009E0582 /* Build All */,
 				8DD76FA90486AB0100D96B5E /* GCDWebServer (Mac) */,
 				E22112591690B4DE0048D2B2 /* GCDWebServer (iOS) */,
+				BF933FD91AD3C65F00E78E05 /* GCDWebServer */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		BF933FD81AD3C65F00E78E05 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E2BE850418E77B730061360B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -447,6 +553,26 @@
 				E2BE850C18E785940061360B /* GCDWebUploader.m in Sources */,
 				E221128F1690B6470048D2B2 /* main.m in Sources */,
 				E28BAE4818F99C810095C089 /* GCDWebServerErrorResponse.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BF933FD51AD3C65F00E78E05 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF933FFC1AD3C72400E78E05 /* GCDWebServerRequest.m in Sources */,
+				BF9340061AD3C73500E78E05 /* GCDWebServerURLEncodedFormRequest.m in Sources */,
+				BF933FF61AD3C72400E78E05 /* GCDWebServerConnection.m in Sources */,
+				BF9340001AD3C73500E78E05 /* GCDWebServerDataRequest.m in Sources */,
+				BF9340041AD3C73500E78E05 /* GCDWebServerMultiPartFormRequest.m in Sources */,
+				BF9340021AD3C73500E78E05 /* GCDWebServerFileRequest.m in Sources */,
+				BF933FFE1AD3C72400E78E05 /* GCDWebServerResponse.m in Sources */,
+				BF93400C1AD3C74300E78E05 /* GCDWebServerFileResponse.m in Sources */,
+				BF93400E1AD3C74300E78E05 /* GCDWebServerStreamedResponse.m in Sources */,
+				BF9340081AD3C74300E78E05 /* GCDWebServerDataResponse.m in Sources */,
+				BF933FF41AD3C72400E78E05 /* GCDWebServer.m in Sources */,
+				BF933FF81AD3C72400E78E05 /* GCDWebServerFunctions.m in Sources */,
+				BF93400A1AD3C74300E78E05 /* GCDWebServerErrorResponse.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -551,6 +677,105 @@
 			};
 			name = Release;
 		};
+		BF933FED1AD3C66000E78E05 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = GCDWebServer/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BF933FEE1AD3C66000E78E05 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = GCDWebServer/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		E22112761690B4DF0048D2B2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -611,6 +836,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		BF933FF11AD3C66000E78E05 /* Build configuration list for PBXNativeTarget "GCDWebServer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF933FED1AD3C66000E78E05 /* Debug */,
+				BF933FEE1AD3C66000E78E05 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		E22112751690B4DF0048D2B2 /* Build configuration list for PBXNativeTarget "GCDWebServer (iOS)" */ = {
 			isa = XCConfigurationList;

--- a/GCDWebServer.xcodeproj/xcshareddata/xcschemes/GCDWebServer.xcscheme
+++ b/GCDWebServer.xcodeproj/xcshareddata/xcschemes/GCDWebServer.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF933FD91AD3C65F00E78E05"
+               BuildableName = "GCDWebServer.framework"
+               BlueprintName = "GCDWebServer"
+               ReferencedContainer = "container:GCDWebServer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF933FE31AD3C65F00E78E05"
+               BuildableName = "GCDWebServerTests.xctest"
+               BlueprintName = "GCDWebServerTests"
+               ReferencedContainer = "container:GCDWebServer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF933FE31AD3C65F00E78E05"
+               BuildableName = "GCDWebServerTests.xctest"
+               BlueprintName = "GCDWebServerTests"
+               ReferencedContainer = "container:GCDWebServer.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF933FD91AD3C65F00E78E05"
+            BuildableName = "GCDWebServer.framework"
+            BlueprintName = "GCDWebServer"
+            ReferencedContainer = "container:GCDWebServer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF933FD91AD3C65F00E78E05"
+            BuildableName = "GCDWebServer.framework"
+            BlueprintName = "GCDWebServer"
+            ReferencedContainer = "container:GCDWebServer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF933FD91AD3C65F00E78E05"
+            BuildableName = "GCDWebServer.framework"
+            BlueprintName = "GCDWebServer"
+            ReferencedContainer = "container:GCDWebServer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -30,6 +30,16 @@
 #import "GCDWebServerRequest.h"
 #import "GCDWebServerResponse.h"
 
+#import "GCDWebServerDataRequest.h"
+#import "GCDWebServerFileRequest.h"
+#import "GCDWebServerMultiPartFormRequest.h"
+#import "GCDWebServerURLEncodedFormRequest.h"
+
+#import "GCDWebServerDataResponse.h"
+#import "GCDWebServerErrorResponse.h"
+#import "GCDWebServerFileResponse.h"
+#import "GCDWebServerStreamedResponse.h"
+
 /**
  *  The GCDWebServerMatchBlock is called for every handler added to the
  *  GCDWebServer whenever a new HTTP request has started (i.e. HTTP headers have

--- a/GCDWebServer/Info.plist
+++ b/GCDWebServer/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>net.pol-online.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
Hi... I added GCDWebServer to a recent swift project of mine, but wanted to be able to add it as a framework rather than a collection of loose classes.  To this end, I did the following:

* added a new target that is a Mac OS X framework
* create a shared scheme to build said target (this helps tools such as Carthage)
* added some header imports to `GCDWebServer.h`

Note that I am not that happy with the way that I had to add the `@import` statements to `GCDWebServer.h`, however, because the umbrella framework header `GCDWebServer.h` is also used as a class header, it make it hard for containing apps to import GCDWebServer as a header.

Feel free to merge (or not) depending on whether this suits your vision of GCDWebServer.  In any event, thanks for writing GCDWebServer... it is a great library.