### PR TITLE
Add support for an optional TXT record for the Bonjour service

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -91,6 +91,14 @@ extern NSString* const GCDWebServerOption_BonjourName;
 extern NSString* const GCDWebServerOption_BonjourType;
 
 /**
+ *  The TXT record used by the GCDWebServer (NSDictionary). If set to nil no TXT
+ *  record will be set for the Bonjour service.
+ *
+ *  The default value is nil.
+ */
+extern NSString* const GCDWebServerOption_TXTRecordDictionary;
+
+/**
  *  Only accept HTTP requests coming from localhost i.e. not from the outside
  *  network (NSNumber / BOOL).
  *

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -50,6 +50,7 @@
 NSString* const GCDWebServerOption_Port = @"Port";
 NSString* const GCDWebServerOption_BonjourName = @"BonjourName";
 NSString* const GCDWebServerOption_BonjourType = @"BonjourType";
+NSString* const GCDWebServerOption_TXTRecordDictionary = @"TXTRecordDictionary";
 NSString* const GCDWebServerOption_BindToLocalhost = @"BindToLocalhost";
 NSString* const GCDWebServerOption_MaxPendingConnections = @"MaxPendingConnections";
 NSString* const GCDWebServerOption_ServerName = @"ServerName";
@@ -561,6 +562,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
   
   NSString* bonjourName = _GetOption(_options, GCDWebServerOption_BonjourName, nil);
   NSString* bonjourType = _GetOption(_options, GCDWebServerOption_BonjourType, @"_http._tcp");
+  NSDictionary* txtRecordDictionary = _GetOption(_options, GCDWebServerOption_TXTRecordDictionary, nil);
   if (bonjourName) {
     _registrationService = CFNetServiceCreate(kCFAllocatorDefault, CFSTR("local."), (__bridge CFStringRef)bonjourType, (__bridge CFStringRef)(bonjourName.length ? bonjourName : _serverName), (SInt32)_port);
     if (_registrationService) {
@@ -570,6 +572,11 @@ static inline NSString* _EncodeBase64(NSString* string) {
       CFNetServiceScheduleWithRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
       CFStreamError streamError = {0};
       CFNetServiceRegisterWithOptions(_registrationService, 0, &streamError);
+
+      if (txtRecordDictionary) {
+        CFDataRef txtRecord = CFNetServiceCreateTXTDataWithDictionary(kCFAllocatorDefault, (__bridge CFDictionaryRef)txtRecordDictionary);
+        CFNetServiceSetTXTData(_registrationService, txtRecord);
+      }
       
       _resolutionService = CFNetServiceCreateCopy(kCFAllocatorDefault, _registrationService);
       if (_resolutionService) {


### PR DESCRIPTION
We use the TXT record part of a NetService to put some additional metadata for clients to use. This allows it to be set optionally. It would only apply if the Bonjour service is run.