### PR TITLE
Fixes error in Carthage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ And finally run `$ pod install`.
 
 You can also use [Carthage](https://github.com/Carthage/Carthage) by adding this line to your Cartfile (3.2.5 is the first release with Carthage support):
 ```
-github "swisspol/GCDWebServer" "~> 3.2.5"
+github "swisspol/GCDWebServer" ~> "3.2.5"
 ```
 
 Then run `$ carthage update` and add the generated frameworks to your Xcode projects (see [Carthage instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)).


### PR DESCRIPTION
~> is like an operator and does not go inside the version string. https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile