### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ And finally run `$ pod install`.
 
 You can also use [Carthage](https://github.com/Carthage/Carthage) by adding this line to your Cartfile (3.2.5 is the first release with Carthage support):
 ```
-github "swisspol/GCDWebServer" ~> "3.2.5"
+github "swisspol/GCDWebServer" ~> 3.2.5
 ```
 
 Then run `$ carthage update` and add the generated frameworks to your Xcode projects (see [Carthage instructions](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)).


### PR DESCRIPTION
the version number should not have quotes, with the quotes carthage errors: 
Parse error: unexpected trailing characters in line: github "swisspol/GCDWebServer" ~> "3.2.5"