### PR TITLE
 Add possibility to set custom cookies in response

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -436,7 +436,7 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
       CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
     }];
     [_response.cookies enumerateObjectsUsingBlock:^(id  __nonnull obj, NSUInteger idx, BOOL * __nonnull stop) {
-      NSString *setCookieString = [NSString stringWithFormat:@"Set-Cookie: %@", obj];
+      NSString *setCookieString = [NSString stringWithFormat:@"Set-Cookie: %@\r\n", obj];
       NSData *cookieData = [setCookieString dataUsingEncoding:NSASCIIStringEncoding];
       CFHTTPMessageAppendBytes(_responseMessage, (UInt8 *)cookieData.bytes, cookieData.length);
 //      CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)@"Set-Cookie", (__bridge CFStringRef)obj);

--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -436,7 +436,10 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
       CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
     }];
     [_response.cookies enumerateObjectsUsingBlock:^(id  __nonnull obj, NSUInteger idx, BOOL * __nonnull stop) {
-      CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)@"Set-Cookie", (__bridge CFStringRef)obj);
+      NSString *setCookieString = [NSString stringWithFormat:@"Set-Cookie: %@", obj];
+      NSData *cookieData = [setCookieString dataUsingEncoding:NSASCIIStringEncoding];
+      CFHTTPMessageAppendBytes(_responseMessage, (UInt8 *)cookieData.bytes, cookieData.length);
+//      CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)@"Set-Cookie", (__bridge CFStringRef)obj);
     }];
     [self _writeHeadersWithCompletionBlock:^(BOOL success) {
       

--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -435,6 +435,9 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
     [_response.additionalHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL* stop) {
       CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
     }];
+    [_response.cookies enumerateObjectsUsingBlock:^(id  __nonnull obj, NSUInteger idx, BOOL * __nonnull stop) {
+      CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)@"Set-Cookie", (__bridge CFStringRef)obj);
+    }];
     [self _writeHeadersWithCompletionBlock:^(BOOL success) {
       
       if (success) {

--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -439,7 +439,6 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
       NSString *setCookieString = [NSString stringWithFormat:@"Set-Cookie: %@\r\n", obj];
       NSData *cookieData = [setCookieString dataUsingEncoding:NSASCIIStringEncoding];
       CFHTTPMessageAppendBytes(_responseMessage, (UInt8 *)cookieData.bytes, cookieData.length);
-//      CFHTTPMessageSetHeaderFieldValue(_responseMessage, (__bridge CFStringRef)@"Set-Cookie", (__bridge CFStringRef)obj);
     }];
     [self _writeHeadersWithCompletionBlock:^(BOOL success) {
       

--- a/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -222,6 +222,7 @@ extern NSString* GCDWebServerStringFromSockAddr(const struct sockaddr* addr, BOO
 
 @interface GCDWebServerResponse ()
 @property(nonatomic, readonly) NSDictionary* additionalHeaders;
+@property(nonatomic, readonly) NSArray* cookies;
 @property(nonatomic, readonly) BOOL usesChunkedTransferEncoding;
 - (void)prepareForReading;
 - (BOOL)performOpen:(NSError**)error;

--- a/GCDWebServer/Core/GCDWebServerResponse.h
+++ b/GCDWebServer/Core/GCDWebServerResponse.h
@@ -177,6 +177,13 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* data, NSError* err
 - (void)setValue:(NSString*)value forAdditionalHeader:(NSString*)header;
 
 /**
+ *  Sets an additional "Set-Cookie" HTTP header on the response.
+ *
+ *  @warning There is no way to remove set cookies for now.
+ */
+- (void)appendCookieString:(NSString *)cookieString;
+
+/**
  *  Convenience method that checks if the contentType property is defined.
  */
 - (BOOL)hasBody;

--- a/GCDWebServer/Core/GCDWebServerResponse.m
+++ b/GCDWebServer/Core/GCDWebServerResponse.m
@@ -166,6 +166,7 @@
   NSDate* _lastModified;
   NSString* _eTag;
   NSMutableDictionary* _headers;
+  NSMutableArray *_cookies;
   BOOL _chunked;
   BOOL _gzipped;
   
@@ -178,7 +179,7 @@
 @implementation GCDWebServerResponse
 
 @synthesize contentType=_type, contentLength=_length, statusCode=_status, cacheControlMaxAge=_maxAge, lastModifiedDate=_lastModified, eTag=_eTag,
-            gzipContentEncodingEnabled=_gzipped, additionalHeaders=_headers;
+            gzipContentEncodingEnabled=_gzipped, additionalHeaders=_headers, cookies=_cookies;
 
 + (instancetype)response {
   return [[[self class] alloc] init];
@@ -192,12 +193,17 @@
     _maxAge = 0;
     _headers = [[NSMutableDictionary alloc] init];
     _encoders = [[NSMutableArray alloc] init];
+    _cookies = [[NSMutableArray alloc] init];
   }
   return self;
 }
 
 - (void)setValue:(NSString*)value forAdditionalHeader:(NSString*)header {
   [_headers setValue:value forKey:header];
+}
+
+- (void)appendCookieString:(NSString *)cookieString {
+  [_cookies addObject:cookieString];
 }
 
 - (BOOL)hasBody {


### PR DESCRIPTION
Closed #190 because of a bug with multiple cookies. This PR contains a fix. But according to http://openradar.appspot.com/15933483, CF uses cookie folding, which is not supported by most browsers.