### PR TITLE
Tentative fix for issue #216

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -759,7 +759,7 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
 - (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion {
   GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_bytesRead);
   @try {
-    _handler.asyncProcessBlock(request, completion);
+    _handler.asyncProcessBlock(request, [completion copy]);
   }
   @catch (NSException* exception) {
     GWS_LOG_EXCEPTION(exception);

--- a/GCDWebServer/Core/GCDWebServerResponse.m
+++ b/GCDWebServer/Core/GCDWebServerResponse.m
@@ -242,7 +242,7 @@
 
 - (void)performReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block {
   if ([_reader respondsToSelector:@selector(asyncReadDataWithCompletion:)]) {
-    [_reader asyncReadDataWithCompletion:block];
+    [_reader asyncReadDataWithCompletion:[block copy]];
   } else {
     NSError* error = nil;
     NSData* data = [_reader readData:&error];


### PR DESCRIPTION
GCDWebServer Blocks called asynchronously fail with `exc_bad_access` when used from a Swift2/XCode7 app. The fix implemented here consist in passing a copy of the block instead of the block itself...it addresses the crashes, however I have a few concerns:

1. I would expect that objc applications already create a copy the block so they can be retained as an ivar or property. I don't think redundant copies would be an issue, but not optimal
2. The rational for the change is that *"a block first residing on the __stack memory__ where it was defined. And copy moved it to the __heap memory__ so it can be used"*  (ref: http://stackoverflow.com/questions/25694017/how-to-store-a-closure-completion-handler-to-call-later).
The distinction between the *heap memory* and the *stack* are beyond my pay grade, so admittedly I don't exactly know what I am doing here
3. I used the copy of the block in `_writeBodyWithCompletionBlock ` and `_startProcessingRequest `...I may have missed other callbacks?