### PR TITLE
Enable support for Podfiles with use_frameworks!

### DIFF
--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -296,7 +296,7 @@
 
 - (instancetype)initWithUploadDirectory:(NSString*)path {
   if ((self = [super init])) {
-    NSBundle* siteBundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:@"GCDWebUploader" ofType:@"bundle"]];
+    NSBundle* siteBundle = [NSBundle bundleWithPath:[[NSBundle bundleForClass:[GCDWebUploader class]] pathForResource:@"GCDWebUploader" ofType:@"bundle"]];
     if (siteBundle == nil) {
       return nil;
     }


### PR DESCRIPTION
The previous implementation looked in the main bundle for the `GCDWebUploader` resource bundle. When using the `use_frameworks!` Podfile option, the resource bundle will be in a framework bundle, not in the main bundle.