### PR TITLE
Fixed issue with dynamically linking CocoaLumberjack

### DIFF
--- a/GCDWebServer.podspec
+++ b/GCDWebServer.podspec
@@ -50,4 +50,9 @@ Pod::Spec.new do |s|
     cs.resource = "GCDWebUploader/GCDWebUploader.bundle"
   end
   
+  s.subspec "CocoaLumberjack" do |cs|
+    cs.dependency 'GCDWebServer/Core'
+    cs.dependency 'CocoaLumberjack', '~> 2.0'
+  end
+
 end


### PR DESCRIPTION
Like discussed in https://github.com/swisspol/GCDWebServer/issues/214 here a change within the Podspec to make the life of users easier.