### PR TITLE
allow serverURL to be assigned on tvOS with wifi connection

### DIFF
--- a/GCDWebServer/Core/GCDWebServerFunctions.m
+++ b/GCDWebServer/Core/GCDWebServerFunctions.m
@@ -261,8 +261,10 @@ NSString* GCDWebServerGetPrimaryIPAddress(BOOL useIPv6) {
   struct ifaddrs* list;
   if (getifaddrs(&list) >= 0) {
     for (struct ifaddrs* ifap = list; ifap; ifap = ifap->ifa_next) {
-#if TARGET_IPHONE_SIMULATOR
-      if (strcmp(ifap->ifa_name, "en0") && strcmp(ifap->ifa_name, "en1"))  // Assume en0 is Ethernet and en1 is WiFi since there is no way to use SystemConfiguration framework in iOS Simulator
+#if TARGET_IPHONE_SIMULATOR  || TARGET_OS_TV
+        // Assume en0 is Ethernet and en1 is WiFi since there is no way to use SystemConfiguration framework in iOS Simulator
+        // Assumption holds for Apple TV running tvOS
+      if (strcmp(ifap->ifa_name, "en0") && strcmp(ifap->ifa_name, "en1"))
 #else
       if (strcmp(ifap->ifa_name, primaryInterface))
 #endif


### PR DESCRIPTION
Hello there, wonderful library you've built.  

I noticed that when running on tvOS with WiFi only, serverURL would be nil.  This seems to be occurring because the tvOS headers set TARGET_OS_IPHONE = 1, which causes en0 to be set as the primary interface in GCDWebServerGetPrimaryIPAddress().   

This patch copies the assumption made about en0 and en1 from the simulator to also apply to tvOS (TARGET_OS_TV), allowing GCDWebServerGetPrimaryIPAddress to return the correct value