### PR TITLE
Correctly use reference to self in block

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -223,11 +223,11 @@ static void _ExecuteMainThreadRunLoopSources() {
   GWS_DCHECK([NSThread isMainThread]);
   if (_backgroundTask == UIBackgroundTaskInvalid) {
     GWS_LOG_DEBUG(@"Did start background task");
+    __weak GCDWebServer *weakself = self;
     _backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-      
-      GWS_LOG_WARNING(@"Application is being suspended while %@ is still connected", [self class]);
-      [self _endBackgroundTask];
-      
+      GCDWebServer *strongself = weakself;
+      GWS_LOG_WARNING(@"Application is being suspended while %@ is still connected", [strongself class]);
+      [strongself _endBackgroundTask];
     }];
   } else {
     GWS_DNOT_REACHED();


### PR DESCRIPTION
We were getting a situation (caused by something else) whereby when executing `[[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler` block in `_startBackgroundTask` line 227 in `GCDWebserver.m` the reference to self used inside the block was no longer present, causing the app to crash.

When referencing `self` inside a block you should always ensure that there is a strong reference to the object, otherwise it may execute code on a nil reference. Therefore I have updating the code to do the following:

* create weak reference to self before block
* turn weak reference back into strong reference inside block
* use strong reference inside block