### PR TITLE
Added __kindof keyword where appropriate

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -52,7 +52,11 @@ typedef GCDWebServerRequest* (^GCDWebServerMatchBlock)(NSString* requestMethod, 
  *  recommended to return a GCDWebServerErrorResponse on error so more useful
  *  information can be returned to the client.
  */
+#if __has_feature(objc_kindof)
+typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(__kindof GCDWebServerRequest* request);
+#else
 typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(GCDWebServerRequest* request);
+#endif
 
 /**
  *  The GCDWebServerAsynchronousProcessBlock works like the GCDWebServerProcessBlock
@@ -65,7 +69,11 @@ typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(GCDWebServerRequest* r
  *  useful information can be returned to the client.
  */
 typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse* response);
+#if __has_feature(objc_kindof)
+typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
+#else
 typedef void (^GCDWebServerAsyncProcessBlock)(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
+#endif
 
 /**
  *  The port used by the GCDWebServer (NSNumber / NSUInteger).

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -52,11 +52,7 @@ typedef GCDWebServerRequest* (^GCDWebServerMatchBlock)(NSString* requestMethod, 
  *  recommended to return a GCDWebServerErrorResponse on error so more useful
  *  information can be returned to the client.
  */
-#if __has_feature(objc_kindof)
 typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(__kindof GCDWebServerRequest* request);
-#else
-typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(GCDWebServerRequest* request);
-#endif
 
 /**
  *  The GCDWebServerAsynchronousProcessBlock works like the GCDWebServerProcessBlock
@@ -69,11 +65,7 @@ typedef GCDWebServerResponse* (^GCDWebServerProcessBlock)(GCDWebServerRequest* r
  *  useful information can be returned to the client.
  */
 typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse* response);
-#if __has_feature(objc_kindof)
 typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
-#else
-typedef void (^GCDWebServerAsyncProcessBlock)(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
-#endif
 
 /**
  *  The port used by the GCDWebServer (NSNumber / NSUInteger).


### PR DESCRIPTION
This avoids errors of the form:

> incompatible block pointer types sending 'GCDWebServerResponse *(^)(GCDWebServerDataRequest *__strong)' to parameter of type 'GCDWebServerProcessBlock' (aka 'GCDWebServerResponse *(^)(GCDWebServerRequest *__strong)')