### PR TITLE
Added method isOpen to check if the response stream is still open

### DIFF
--- a/GCDWebServer/Core/GCDWebServerResponse.h
+++ b/GCDWebServer/Core/GCDWebServerResponse.h
@@ -69,6 +69,11 @@ typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* data, NSError* err
  */
 - (void)close;
 
+/**
+ *  Convenience method that checks if the stream to send the body is still open.
+ */
+- (BOOL)isOpened;
+
 @optional
 
 /**

--- a/GCDWebServer/Core/GCDWebServerResponse.m
+++ b/GCDWebServer/Core/GCDWebServerResponse.m
@@ -72,6 +72,10 @@
   [_reader close];
 }
 
+- (BOOL)isOpened {
+  return [_reader isOpened];
+}
+
 @end
 
 @interface GCDWebServerGZipEncoder () {
@@ -220,6 +224,10 @@
   ;
 }
 
+- (BOOL)isOpened {
+  return _opened;
+}
+
 - (void)prepareForReading {
   _reader = self;
   if (_gzipped) {
@@ -251,8 +259,11 @@
 }
 
 - (void)performClose {
-  GWS_DCHECK(_opened);
+  if (!_opened) {
+    return;
+  }
   [_reader close];
+  _opened = NO;
 }
 
 - (NSString*)description {


### PR DESCRIPTION
This new method lets us know if the client cancelled its requests to the server. This is the simplest change I could think of, but I'm open to suggestions 😄 