### PR TITLE
Typo in GCDWebServerGZipDecoder:open

### DIFF
--- a/GCDWebServer/Core/GCDWebServerRequest.m
+++ b/GCDWebServer/Core/GCDWebServerRequest.m
@@ -94,7 +94,7 @@ NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerReque
     return NO;
   }
   if (![super open:error]) {
-    deflateEnd(&_stream);
+    inflateEnd(&_stream);
     return NO;
   }
   return YES;


### PR DESCRIPTION
I haven't tested or dug into this, as I just happened to spot it while looking through a colleagues code.

It looks like `inflateInit2` is called and then `deflateEnd` on error. I'm wondering if this is a copy and paste issue from `GCDWebServerGZipEncoder` and really it should be `inflateEnd` here instead?