### PR TITLE
Removed cs.default_subspec from subspecs as this is now disallowed

### DIFF
--- a/GCDWebServer.podspec
+++ b/GCDWebServer.podspec
@@ -39,8 +39,6 @@ Pod::Spec.new do |s|
   end
   
   s.subspec 'WebDAV' do |cs|
-    cs.default_subspec = 'Core'
-
     cs.subspec "Core" do |ccs|
       ccs.dependency 'GCDWebServer/Core'
       ccs.source_files = 'GCDWebDAVServer/*.{h,m}'
@@ -58,8 +56,6 @@ Pod::Spec.new do |s|
   end
   
   s.subspec 'WebUploader' do |cs|
-    cs.default_subspec = 'Core'
-
     cs.subspec "Core" do |ccs|
       ccs.dependency 'GCDWebServer/Core'
       ccs.source_files = 'GCDWebUploader/*.{h,m}'


### PR DESCRIPTION
According to this https://github.com/CocoaPods/CocoaPods/issues/5228, `default_subspecs` is now disallowed for subspecs, which causes pod lint validation to fail. This is the reason why pod version 3.3.3 is not available on the main CocoaSpecs reason. 

```
pod install
Analyzing dependencies
Pre-downloading: `GCDWebServer` from `https://github.com/bizz84/GCDWebServer`, commit `5834770e083cc4e72c7fa13f9c3f0d5accad89da`
[!] The `GCDWebServer` pod failed to validate due to 2 errors:
    - ERROR | attributes: Can't set `default_subspecs` attribute for subspecs (in `GCDWebServer/WebDAV`).
    - ERROR | attributes: Can't set `default_subspecs` attribute for subspecs (in `GCDWebServer/WebUploader`).
```
