### PR TITLE
Static analyser warning

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -756,9 +756,17 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
   return response;
 }
 
+//***
+// Static analyzer comment: for discussion only.  Do not leave in production code.
+// warning: Called function pointer is null (null dereference)
+//***
+
 - (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion {
   GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_bytesRead);
-  _handler.asyncProcessBlock(request, [completion copy]);
+// Silence static analyzer warning if _handler == nil.
+  if (_handler) {
+    _handler.asyncProcessBlock(request, [completion copy]);
+  }
 }
 
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25


### PR DESCRIPTION
_This is a bug report (and possible fix), intended to be for discussion.  I made a bug report on Stack Overflow yesterday but it was inevitably closed as off-topic._

Running **Analyze** in Xcode 7.3.1 and 8.0GM against version **3.3.3** of GCDWebServer (all targets) produces the following warning.

`Called function pointer is null (null dereference)`

This is in reference to _handler and is new since 3.3.2.  I believe it has occurred after removal of try/catch.

Many thanks.