### PR TITLE
add additionalHiddenResources property to WebDAV server

### DIFF
--- a/GCDWebDAVServer/GCDWebDAVServer.h
+++ b/GCDWebDAVServer/GCDWebDAVServer.h
@@ -104,6 +104,14 @@
 @property(nonatomic) BOOL allowHiddenItems;
 
 /**
+ *  A set of file paths (relative to the upload directory) that should be hidden
+ *  in addition to the files covered by `allowHiddenItems`.
+ *
+ *  The default value is nil i.e. all files are visible.
+ */
+@property(nonatomic, copy) NSArray* additionalHiddenResources;
+
+/**
  *  This method is the designated initializer for the class.
  */
 - (instancetype)initWithUploadDirectory:(NSString*)path;

--- a/GCDWebDAVServer/GCDWebDAVServer.m
+++ b/GCDWebDAVServer/GCDWebDAVServer.m
@@ -101,7 +101,7 @@ static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
   }
   
   NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHidden) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+  if (([itemName hasPrefix:@"."] && !_allowHidden) || ([self.additionalHiddenResources containsObject:relativePath]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Downlading item name \"%@\" is not allowed", itemName];
   }
   
@@ -144,7 +144,7 @@ static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
   }
   
   NSString* fileName = [absolutePath lastPathComponent];
-  if (([fileName hasPrefix:@"."] && !_allowHidden) || ![self _checkFileExtension:fileName]) {
+  if (([fileName hasPrefix:@"."] && !_allowHidden) || [self.additionalHiddenResources containsObject:relativePath] || ![self _checkFileExtension:fileName]) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file name \"%@\" is not allowed", fileName];
   }
   
@@ -180,7 +180,7 @@ static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
   }
   
   NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHidden) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+  if (([itemName hasPrefix:@"."] && !_allowHidden) || [self.additionalHiddenResources containsObject:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting item name \"%@\" is not allowed", itemName];
   }
   
@@ -217,7 +217,7 @@ static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
   }
   
   NSString* directoryName = [absolutePath lastPathComponent];
-  if (!_allowHidden && [directoryName hasPrefix:@"."]) {
+  if ((!_allowHidden && [directoryName hasPrefix:@"."]) || [self.additionalHiddenResources containsObject:relativePath]) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory name \"%@\" is not allowed", directoryName];
   }
   
@@ -281,7 +281,7 @@ static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
   }
   
   NSString* itemName = [dstAbsolutePath lastPathComponent];
-  if ((!_allowHidden && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+  if ((!_allowHidden && [itemName hasPrefix:@"."]) || [self.additionalHiddenResources containsObject:dstRelativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ to item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", itemName];
   }
   
@@ -447,7 +447,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar* name
   }
   
   NSString* itemName = [absolutePath lastPathComponent];
-  if (([itemName hasPrefix:@"."] && !_allowHidden) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+  if (([itemName hasPrefix:@"."] && !_allowHidden) || [self.additionalHiddenResources containsObject:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Retrieving properties for item name \"%@\" is not allowed", itemName];
   }
   
@@ -471,7 +471,8 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar* name
       relativePath = [relativePath stringByAppendingString:@"/"];
     }
     for (NSString* item in items) {
-      if (_allowHidden || ![item hasPrefix:@"."]) {
+      NSString *itemRelativePath = [relativePath stringByAppendingPathComponent:item];
+      if ((_allowHidden || ![item hasPrefix:@"."]) && ![self.additionalHiddenResources containsObject:itemRelativePath]) {
         [self _addPropertyResponseForItem:[absolutePath stringByAppendingPathComponent:item] resource:[relativePath stringByAppendingString:item] properties:properties xmlString:xmlString];
       }
     }
@@ -539,7 +540,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar* name
   }
   
   NSString* itemName = [absolutePath lastPathComponent];
-  if ((!_allowHidden && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+  if ((!_allowHidden && [itemName hasPrefix:@"."]) || [self.additionalHiddenResources containsObject:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking item name \"%@\" is not allowed", itemName];
   }
   
@@ -599,7 +600,7 @@ static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar* name
   }
   
   NSString* itemName = [absolutePath lastPathComponent];
-  if ((!_allowHidden && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+  if ((!_allowHidden && [itemName hasPrefix:@"."]) || [self.additionalHiddenResources containsObject:relativePath] || (!isDirectory && ![self _checkFileExtension:itemName])) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Unlocking item name \"%@\" is not allowed", itemName];
   }
   


### PR DESCRIPTION
The WebDAV server implementation currently only allows to filter out hidden files and directories. However there might be other resources that should be hidden from WebDAV.

We experienced this issue when making the Documents directory of an iOS app available through WebDAV: There is an Inbox folder in there that is used for intermediate files when they are handed over from another app. This folder should not show up in the WebDAV list as you don't have write permissions to it and it is used only temporarily. However as we don't control this folder and it is created from the operating system, there currently is no way to hide this.

This PR introduces a property that lets you specify relative path's that are not accessible through WebDAV and filters them out at the same locations where the hidden files are controlled as well.

Another option would be to use absolute file path's here as we want to guard resources on the disk, but since everything else in the server implementation seems to use relative paths, I didn't want to start using absolute paths for this one, as I figured that might cause confusion.