### PR TITLE
add public interface for active connections

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -303,6 +303,11 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
 @property(nonatomic, readonly, getter=isRunning) BOOL running;
 
 /**
+ *  Returns YES if the server has active connections.
+ */
+@property(nonatomic, readonly, getter=hasActiveConnections) BOOL activeConnections;
+
+/**
  *  Returns the port used by the server.
  *
  *  @warning This property is only valid if the server is running.

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -787,6 +787,10 @@ static inline NSString* _EncodeBase64(NSString* string) {
   return (_options ? YES : NO);
 }
 
+- (BOOL)hasActiveConnections {
+    return _activeConnections > 0;
+}
+
 - (void)stop {
   if (_options) {
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
Adds a public interface to check if the web server has active connections. This can be used to e.g. check if it is save to shut down the web server.