### PR TITLE
Remove CocoaLumberjack version dependency in podspec

### DIFF
--- a/GCDWebServer.podspec
+++ b/GCDWebServer.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   
   s.subspec "CocoaLumberjack" do |cs|
     cs.dependency 'GCDWebServer/Core'
-    cs.dependency 'CocoaLumberjack', '~> 2'
+    cs.dependency 'CocoaLumberjack'
   end
   
   s.subspec 'WebDAV' do |cs|


### PR DESCRIPTION
Currently, the podspec requires CocoaLumberjack 2. CocoaLumberjack is now on 3, which is necessary for Swift 3 usage. However, the migration from CocoaLumberjack 2 to CocoaLumberjack 3 is painful, and it seems premature to force people on 3. Removing the version dependency from the podspec altogether allows pod consumers to choose the version of CocoaLumberjack that works best for them.