### PR TITLE
Fix prototype declaration warning (new with Xcode 9)

### DIFF
--- a/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -189,7 +189,7 @@ static inline NSError* GCDWebServerMakePosixError(int code) {
   return [NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithUTF8String:strerror(code)]}];
 }
 
-extern void GCDWebServerInitializeFunctions();
+extern void GCDWebServerInitializeFunctions(void);
 extern NSString* GCDWebServerNormalizeHeaderValue(NSString* value);
 extern NSString* GCDWebServerTruncateHeaderValue(NSString* value);
 extern NSString* GCDWebServerExtractHeaderValueParameter(NSString* header, NSString* attribute);


### PR DESCRIPTION
I have not enabled the new Xcode 9 recommended warnings as part of this PR, just this minor fix for if they are enabled.

A separate PR could be made to enable these warnings by default in GCDWebServer's own .xcodeproj if desired - either now or when Xcode 9 is out of beta.