### PR TITLE
Allow applications to override the default file mimetype mapping

### DIFF
--- a/GCDWebServer/Core/GCDWebServerFunctions.h
+++ b/GCDWebServer/Core/GCDWebServerFunctions.h
@@ -30,6 +30,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+  
+/** 
+ *  Overrides the default extension-to-mimetype mapping. The extension argument
+ *  does not include the prefix dot.
+ */
+void GCDWebServerSetMimeTypeForExtension(NSString* extension, NSString* mimeType);
 
 /**
  *  Converts a file extension to the corresponding MIME type.


### PR DESCRIPTION
The defaults are based on UTType, but sometimes this needs to be customized. 
For example, the default type for `m3u8` is `audio/mpegurl`, but Apple's HLS documentation requires it to be either `application/x-mpegURL` or `vnd.apple.mpegURL`. 
Another example: `vtt` (WebVTT) files should be served as `text/vtt`, but UTType provides `nil`.
