### PR TITLE
Add option to keep directory tree for GCDWebUploader

### DIFF
--- a/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/index.html
+++ b/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/index.html
@@ -49,6 +49,7 @@
     <script type="text/javascript" src="js/tmpl.min.js"></script>
     <script type="text/javascript">
       var _device = "%device%";
+      var _keepDirectoryTree = %keepDirectoryTree%;
     </script>
     <script type="text/javascript" src="js/index.js"></script>
   </head>

--- a/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
+++ b/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
@@ -211,7 +211,7 @@ $(document).ready(function() {
     
     add: function(e, data) {
       var file = data.files[0];
-      var relativePath = _keepDirectoryTree ? file.relativePath : "";
+      var relativePath = (_keepDirectoryTree && file.relativePath !== undefined) ? file.relativePath : "";
       data.formData = {
         path: _path + relativePath
       };

--- a/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
+++ b/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
@@ -211,11 +211,12 @@ $(document).ready(function() {
     
     add: function(e, data) {
       var file = data.files[0];
+      var relativePath = _keepDirectoryTree ? file.relativePath : "";
       data.formData = {
-        path: _path
+        path: _path + relativePath
       };
       data.context = $(tmpl("template-uploads", {
-        path: _path + file.name
+        path: _path + relativePath + file.name
       })).appendTo("#uploads");
       var jqXHR = data.submit();
       data.context.find("button").click(function(event) {

--- a/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
+++ b/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
@@ -212,6 +212,9 @@ $(document).ready(function() {
     add: function(e, data) {
       var file = data.files[0];
       var relativePath = (_keepDirectoryTree && file.relativePath != null) ? file.relativePath : "";
+      if (typeof relativePath == "undefined" || relativePath == "undefined") {
+        relativePath = "";
+      }
       data.formData = {
         path: _path + relativePath
       };

--- a/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
+++ b/GCDWebUploader/GCDWebUploader.bundle/Contents/Resources/js/index.js
@@ -211,7 +211,7 @@ $(document).ready(function() {
     
     add: function(e, data) {
       var file = data.files[0];
-      var relativePath = (_keepDirectoryTree && file.relativePath !== undefined) ? file.relativePath : "";
+      var relativePath = (_keepDirectoryTree && file.relativePath != null) ? file.relativePath : "";
       data.formData = {
         path: _path + relativePath
       };

--- a/GCDWebUploader/GCDWebUploader.h
+++ b/GCDWebUploader/GCDWebUploader.h
@@ -104,6 +104,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) BOOL allowHiddenItems;
 
 /**
+ *  Sets if dropped directory should be uploaded keeping the directory structure
+ *  with all subdirectories or should upload contained files flat
+ *  to target directory.
+ *  Dropping folders suppored in Chrome 21+.
+ *
+ *  The default value is YES.
+ */
+@property(nonatomic) BOOL keepDirectoryTree;
+
+/**
  *  Sets the title for the uploader web interface.
  *
  *  The default value is the application name.

--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -312,8 +312,10 @@ NS_ASSUME_NONNULL_END
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file \"%@\" to \"%@\" is not permitted", file.fileName, relativePath];
   }
   
-  NSString *targetDirectory = [absolutePath stringByDeletingLastPathComponent];
-  [[NSFileManager defaultManager] createDirectoryAtPath:targetDirectory withIntermediateDirectories:YES attributes:nil error:NULL];
+  if (_keepDirectoryTree) {
+    NSString *targetDirectory = [absolutePath stringByDeletingLastPathComponent];
+    [[NSFileManager defaultManager] createDirectoryAtPath:targetDirectory withIntermediateDirectories:YES attributes:nil error:NULL];
+  }
 
   NSError* error = nil;
   if (![[NSFileManager defaultManager] moveItemAtPath:file.temporaryPath toPath:absolutePath error:&error]) {

--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -126,7 +126,6 @@ NS_ASSUME_NONNULL_END
 #endif
                      footer = [NSString stringWithFormat:[siteBundle localizedStringForKey:@"FOOTER_FORMAT" value:@"" table:nil], name, version];
                    }
-                     
                    NSString *keepDirectoryTree = server.keepDirectoryTree ? @"true" : @"false";
                 
                    return [GCDWebServerDataResponse responseWithHTMLTemplate:(NSString*)[siteBundle pathForResource:@"index" ofType:@"html"]

--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -126,6 +126,9 @@ NS_ASSUME_NONNULL_END
 #endif
                      footer = [NSString stringWithFormat:[siteBundle localizedStringForKey:@"FOOTER_FORMAT" value:@"" table:nil], name, version];
                    }
+                     
+                   NSString *keepDirectoryTree = server.keepDirectoryTree ? @"true" : @"false";
+                
                    return [GCDWebServerDataResponse responseWithHTMLTemplate:(NSString*)[siteBundle pathForResource:@"index" ofType:@"html"]
                                                                    variables:@{
                                                                      @"device" : device,
@@ -308,6 +311,9 @@ NS_ASSUME_NONNULL_END
   if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:file.temporaryPath]) {
     return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file \"%@\" to \"%@\" is not permitted", file.fileName, relativePath];
   }
+  
+  NSString *targetDirectory = [absolutePath stringByDeletingLastPathComponent];
+  [[NSFileManager defaultManager] createDirectoryAtPath:targetDirectory withIntermediateDirectories:YES attributes:nil error:NULL];
 
   NSError* error = nil;
   if (![[NSFileManager defaultManager] moveItemAtPath:file.temporaryPath toPath:absolutePath error:&error]) {

--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -136,7 +136,8 @@ NS_ASSUME_NONNULL_END
                                                                      @"header" : header,
                                                                      @"prologue" : prologue,
                                                                      @"epilogue" : epilogue,
-                                                                     @"footer" : footer
+                                                                     @"footer" : footer,
+                                                                     @"keepDirectoryTree": keepDirectoryTree
                                                                    }];
 
                  }];


### PR DESCRIPTION
I have a music player app and it's very useful in my scenario to keep directory tree (for example `/Artist/Album/Uploaded Track.mp3`) when dropping folders into the browser window.
Drag and dropping folders are supported since Chrome 21+.

Now when you drop a folder, it would upload all contained files _flat_ into the current directory.

Maybe it would be useful for the community.