### PR TITLE
Update GCDWebServerConnection.m

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -783,7 +783,9 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
 
 - (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion {
   GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
-  _handler.asyncProcessBlock(request, [completion copy]);
+  if (_handler != nil) {
+    _handler.asyncProcessBlock(request, [completion copy]);
+  }
 }
 
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25


### PR DESCRIPTION
fix for XCode 9.1 static analysis warning

`Core/GCDWebServerConnection.m:786:3: Called function pointer is null (null dereference)`