### PR TITLE
Added support to override built-in logger at runtime

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -70,6 +70,12 @@ typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse* _Nullable resp
 typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
 
 /**
+ *  The GCDWebServerBuiltInLoggerBlock is used to override the built-in logger at runtime.
+ *  The message parameter is the formatted log message with the logging level.
+ */
+typedef void (^GCDWebServerBuiltInLoggerBlock)(NSString* _Nonnull message);
+
+/**
  *  The port used by the GCDWebServer (NSNumber / NSUInteger).
  *
  *  The default value is 0 i.e. let the OS pick a random port.
@@ -572,6 +578,14 @@ extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
  *  ERROR = 4
  */
 + (void)setLogLevel:(int)level;
+
+/**
+ *  Set a logger to be used instead of the built-in logger which logs to stderr.
+ *
+ *  IMPORTANT: In order for this override to work, you should not be specifying
+ *  a custom logger at compile time with "__GCDWEBSERVER_LOGGING_HEADER__".
+ */
++ (void)setBuiltInLogger:(GCDWebServerBuiltInLoggerBlock)block;
 
 /**
  *  Logs a message to the logging facility at the VERBOSE level.

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -71,9 +71,10 @@ typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* requ
 
 /**
  *  The GCDWebServerBuiltInLoggerBlock is used to override the built-in logger at runtime.
- *  The message parameter is the formatted log message with the logging level.
+ *  The block will be passed the log level and the log message, see setLogLevel for
+ *  documentation of the log levels for the built-in logger.
  */
-typedef void (^GCDWebServerBuiltInLoggerBlock)(NSString* _Nonnull message);
+typedef void (^GCDWebServerBuiltInLoggerBlock)(int level, NSString* _Nonnull message);
 
 /**
  *  The port used by the GCDWebServer (NSNumber / NSUInteger).

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -85,18 +85,24 @@ static BOOL _run;
 
 #ifdef __GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__
 
+static GCDWebServerBuiltInLoggerBlock _builtInLoggerBlock;
+
 void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* format, ...) {
   static const char* levelNames[] = {"DEBUG", "VERBOSE", "INFO", "WARNING", "ERROR"};
   static int enableLogging = -1;
   if (enableLogging < 0) {
     enableLogging = (isatty(STDERR_FILENO) ? 1 : 0);
   }
-  if (enableLogging) {
+  if (_builtInLoggerBlock || enableLogging) {
     va_list arguments;
     va_start(arguments, format);
     NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
     va_end(arguments);
-    fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
+    if (_builtInLoggerBlock) {
+      _builtInLoggerBlock([NSString stringWithFormat:@"[%s] %s", levelNames[level], [message UTF8String]]);
+    } else {
+      fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
+    }
   }
 }
 
@@ -1088,6 +1094,14 @@ static inline NSString* _EncodeBase64(NSString* string) {
   [XLSharedFacility setMinLogLevel:level];
 #elif defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
   GCDWebServerLogLevel = level;
+#endif
+}
+
++ (void)setBuiltInLogger:(GCDWebServerBuiltInLoggerBlock)block {
+#if defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
+  _builtInLoggerBlock = block;
+#else
+  GWS_DCHECK(false) // Built-in logger must be enabled in order to override
 #endif
 }
 

--- a/GCDWebServer/Core/GCDWebServer.m
+++ b/GCDWebServer/Core/GCDWebServer.m
@@ -99,7 +99,7 @@ void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* format, ..
     NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
     va_end(arguments);
     if (_builtInLoggerBlock) {
-      _builtInLoggerBlock([NSString stringWithFormat:@"[%s] %s", levelNames[level], [message UTF8String]]);
+      _builtInLoggerBlock(level, message);
     } else {
       fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
     }
@@ -1101,7 +1101,7 @@ static inline NSString* _EncodeBase64(NSString* string) {
 #if defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
   _builtInLoggerBlock = block;
 #else
-  GWS_DCHECK(false) // Built-in logger must be enabled in order to override
+  GWS_DNOT_REACHED(); // Built-in logger must be enabled in order to override
 #endif
 }
 


### PR DESCRIPTION
This change adds a block based API for specifying a different built-in logging method at runtime. This is used instead of logging to stderr.

This is needed for cases where GCDWebServer can't be configured at compile time with a custom logger, such as when building with Carthage.