### PR TITLE
Fixed import in Swift example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ int main(int argc, const char* argv[]) {
 ***webServer.swift***
 ```swift
 import Foundation
-import GCDWebServer
+import GCDWebServers
 
 func initWebServer() {
 
@@ -172,8 +172,8 @@ func initWebServer() {
 
 ***WebServer-Bridging-Header.h***
 ```objectivec
-#import <GCDWebServer/GCDWebServer.h>
-#import <GCDWebServer/GCDWebServerDataResponse.h>
+#import <GCDWebServers/GCDWebServer.h>
+#import <GCDWebServers/GCDWebServerDataResponse.h>
 ```
 
 Web Based Uploads in iOS Apps


### PR DESCRIPTION
When I tried to import `GCDWebServer` in my project, I had to add an "s" to make it work. It looks like the module has either been mistakenly named in the project or in the readme. 

Since it would be a breaking change to rename it in the project, I fixed the readme so people (like me) don't get confused when using the library in Swift for the first time.