### PR TITLE
[Proposal] Add "Bind To IP" and Bind To IPv6?" options

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -116,6 +116,23 @@ extern NSString* const GCDWebServerOption_RequestNATPortMapping;
 extern NSString* const GCDWebServerOption_BindToLocalhost;
 
 /**
+ *  Bind to the interface with the given IP. Overrides the GCDWebServerOption_BindToLocalhost option.
+ *
+ *  The default value is `nil`, and the server will bind to all available interfaces, or the local loopback
+ *  if GCDWebServerOption_BindToLocalhost is set to YES.
+ */
+extern NSString* const GCDWebServerOption_BindToIP;
+
+/**
+ *  Bind to an IPv6 address.
+ *
+ *  The default value is YES.
+ *
+ *  @warning IPv6 binding should be turned off if using the GCDWebServerOption_BindToIP option.
+ */
+extern NSString* const GCDWebServerOption_BindToIPv6;
+
+/**
  *  The maximum number of incoming HTTP requests that can be queued waiting to
  *  be handled before new ones are dropped (NSNumber / NSUInteger).
  *


### PR DESCRIPTION
First, thank you for the wonderful framework! 

I'm using it in a project that has yet to ship, but for our use case I needed to make a couple of changes. This pull request is a proposal for those to be merged back into the main codebase. 

By default, there will be absolutely no change in behaviour - the changes made are both opt-in.

First is the  `GCDWebServerOption_BindToIP` option. This is similar in concept to `GCDWebServerOption_BindToLocalhost`, but you explicitly give the IP address of the interface to bind to. We use this because we want to be publicly available through one specific interface.

The second is the `GCDWebServerOption_BindToIPv6`, which is a boolean option. Setting this to `false`/`@NO` will turn off all IPv6 binding. We need this because we work with hardware that is very explicitly IPv4-only, so the IPv6 stuff is unneeded.

These changed were just kind of shoved in without a huge amount of thought to the larger API, since we were trying to get things working. If you're OK with the concept but not the implementation, please give feedback and I can make it better.

Thank you!