### PR TITLE
API improvements to allow for monitoring transfer progress

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.h
+++ b/GCDWebServer/Core/GCDWebServerConnection.h
@@ -86,6 +86,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger totalBytesRead;
 
 /**
+ *  Returns the total number of bytes that the connection expects to receive by
+ *  the end of the exchange with the remote peer (i.e. client).
+ *
+ *  This property will be set to "NSUIntegerMax" if the request hasn't been received
+ *  yet, has no body or if there is a body but no "Content-Length" header, typically
+ *  because chunked transfer encoding is used.
+ */
+- (NSUInteger)expectedFinalReadByteTotal;
+
+/**
  *  Returns the total number of bytes sent to the remote peer (i.e. client) so far.
  */
 @property(nonatomic, readonly) NSUInteger totalBytesWritten;

--- a/GCDWebServer/Core/GCDWebServerConnection.h
+++ b/GCDWebServer/Core/GCDWebServerConnection.h
@@ -93,12 +93,22 @@ NS_ASSUME_NONNULL_BEGIN
  *  yet, has no body or if there is a body but no "Content-Length" header, typically
  *  because chunked transfer encoding is used.
  */
-- (NSUInteger)expectedFinalReadByteTotal;
+- (NSUInteger)expectedFinalTotalReadBytes;
 
 /**
  *  Returns the total number of bytes sent to the remote peer (i.e. client) so far.
  */
 @property(nonatomic, readonly) NSUInteger totalBytesWritten;
+
+/**
+ *  Returns the total number of bytes that the connection expects to write by
+ *  the end of the exchange with the remote peer (i.e. client).
+ *
+ *  This property will be set to "NSUIntegerMax" if the response hasn't been formed
+ *  yet, has no body or if there is a body but no "Content-Length" header, typically
+ *  because chunked transfer encoding is used.
+ */
+- (NSUInteger)expectedFinalTotalWrittenBytes;
 
 @end
 

--- a/GCDWebServer/Core/GCDWebServerConnection.h
+++ b/GCDWebServer/Core/GCDWebServerConnection.h
@@ -125,6 +125,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didWriteBytes:(const void*)bytes length:(NSUInteger)length;
 
 /**
+ *  This method is called once the request object is populated.
+ *
+ *  If you're looking to monitor data read progress, this method
+ *  is useful for receiving important information such as content
+ *  length before all of the data is fully received from the remote
+ *  peer and request internally processed.
+ */
+- (void)didParseRequest:(GCDWebServerRequest *)request;
+
+/**
  *  This method is called after the HTTP headers have been received to
  *  allow replacing the request URL by another one.
  *


### PR DESCRIPTION
My app requires visibility into the progress of a request being read by GCDWebServer. As seen in #181, #174, and #22, this isn't an entirely new problem. There's a solution mentioned there as follows:

1. Subclass GCDWebServerConnection
2. Override `didReadBytes:length:` to be notified when bytes are read and `processRequest:completion:` to get the request and its content length.

Unfortunately, it appears that internal changes since these issues (in 2015) have changed the order of these methods being called. Currently, they `processRequest:completion:` is called after all of the bytes are received, despite the connection owning a `GCDWebServerRequest`.

- This pull request adds a new method to connections that can be overridden to receive the request, called `didParseRequest:`. When this is called, we've received just enough data to get the headers, allowing us to read the content length and calculate the percentage complete.
- Since the response is formulated in the connection instance, there was no need for an additional method for tracking write progress.

Another problem I encountered was that `totalBytesRead` includes the header data's bytes. This is unlike the content length of `GCDWebServerRequest`, which only accounts for the body.

- To solve this, I added two new methods to `GCDWebServerConnection` that calculate the amount of bytes that the connection expects to receive from/send to the remote peer once the exchange is complete.  Named `expectedFinalTotalReadBytes` and `expectedFinalTotalWrittenBytes`, it adds the headers' and body's lengths.

With these two changes, it is possible to monitor the progress of a request being received and sent by GCDWebServer.