### PR TITLE
Add full Swift Package manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.build/
+.swiftpm/
 xcuserdata
 project.xcworkspace
 /build

--- a/Frameworks/Tests.m
+++ b/Frameworks/Tests.m
@@ -1,5 +1,6 @@
-#import <GCDWebServers/GCDWebServers.h>
 #import <XCTest/XCTest.h>
+
+@import GCDWebServers;
 
 #pragma clang diagnostic ignored "-Weverything"  // Prevent "messaging to unqualified id" warnings
 

--- a/GCDWebUploader/GCDWebUploader.m
+++ b/GCDWebUploader/GCDWebUploader.m
@@ -66,7 +66,13 @@ NS_ASSUME_NONNULL_END
 
 - (instancetype)initWithUploadDirectory:(NSString*)path {
   if ((self = [super init])) {
-    NSString* bundlePath = [[NSBundle bundleForClass:[GCDWebUploader class]] pathForResource:@"GCDWebUploader" ofType:@"bundle"];
+#if SWIFT_PACKAGE
+    NSBundle* bundle = SWIFTPM_MODULE_BUNDLE;
+#else
+    NSBundle* bundle = [NSBundle bundleForClass:[GCDWebUploader class]];
+#endif
+
+    NSString* bundlePath = [bundle pathForResource:@"GCDWebUploader" ofType:@"bundle"];
     if (bundlePath == nil) {
       return nil;
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,58 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GCDWebServer",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "GCDWebServers",
+            targets: ["GCDWebServers"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "GCDWebServers",
+            dependencies: [],
+            path: ".",
+            exclude: [
+                "Frameworks",
+                "iOS",
+                "Mac",
+                "Tests",
+                "tvOS",
+                "Package.swift",
+                "GCDWebServer.podspec",
+                "Run-Tests.sh",
+                "format-source.sh",
+                "README.md",
+                "LICENSE"
+            ],
+            resources: [
+                .copy("GCDWebUploader/GCDWebUploader.bundle"),
+            ],
+            cSettings:[
+                .headerSearchPath("GCDWebServer/Core"),
+                .headerSearchPath("GCDWebServer/Requests"),
+                .headerSearchPath("GCDWebServer/Responses"),
+            ]
+        ),
+        .testTarget(
+            name: "GCDWebServersTests",
+            dependencies: ["GCDWebServers"],
+            path: "Frameworks",
+            exclude: [
+                "GCDWebServers.h",
+                "Info.plist",
+                "module.modulemap"
+            ]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -43,9 +43,39 @@ Requirements:
 Getting Started
 ===============
 
+Swift Package Manager
+---------------------
+
+1. From the Xcode menu click File > Swift Packages > Add Package Dependency.
+2. In the dialog that appears, enter the repository URL: https://github.com/swisspol/GCDWebServer.
+3. In Version, select Up to Next Major and take the default option.
+4. Choose 'GCDWebServers' in the Package Product column.
+
+If you are developing a SPM package, you must add the following dependency to your Package.swift:
+```swift
+dependencies: [
+  .package(url: "https://github.com/swisspol/GCDWebServer", from: "3.5.5"),
+]
+```
+
+Finally you declare GCDWebServer as a dependency on your target:
+```swift
+.target(
+  name: "YOUR_TARGET_NAME",
+  dependencies: [
+    .product(name: "GCDWebServers", package: "GCDWebServer"),
+  ]),
+```
+
+Manually
+---------
+
 Download or check out the [latest release](https://github.com/swisspol/GCDWebServer/releases) of GCDWebServer then add the entire "GCDWebServer" subfolder to your Xcode project. If you intend to use one of the extensions like GCDWebDAVServer or GCDWebUploader, add these subfolders as well. Finally link to `libz` (via Target > Build Phases > Link Binary With Libraries) and add `$(SDKROOT)/usr/include/libxml2` to your header search paths (via Target > Build Settings > HEADER_SEARCH_PATHS).
 
-Alternatively, you can install GCDWebServer using [CocoaPods](http://cocoapods.org/) by simply adding this line to your Podfile:
+CocoaPods
+---------
+
+You can install GCDWebServer using [CocoaPods](http://cocoapods.org/). Simply add this line to your Podfile:
 ```
 pod "GCDWebServer", "~> 3.0"
 ```
@@ -59,6 +89,9 @@ pod "GCDWebServer/WebDAV", "~> 3.0"
 ```
 
 And finally run `$ pod install`.
+
+Carthage
+---------
 
 You can also use [Carthage](https://github.com/Carthage/Carthage) by adding this line to your Cartfile (3.2.5 is the first release with Carthage support):
 ```

--- a/include/GCDWebServers/GCDWebDAVServer.h
+++ b/include/GCDWebServers/GCDWebDAVServer.h
@@ -1,0 +1,1 @@
+../../GCDWebDAVServer/GCDWebDAVServer.h

--- a/include/GCDWebServers/GCDWebServer.h
+++ b/include/GCDWebServers/GCDWebServer.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Core/GCDWebServer.h

--- a/include/GCDWebServers/GCDWebServerConnection.h
+++ b/include/GCDWebServers/GCDWebServerConnection.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Core/GCDWebServerConnection.h

--- a/include/GCDWebServers/GCDWebServerDataRequest.h
+++ b/include/GCDWebServers/GCDWebServerDataRequest.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Requests/GCDWebServerDataRequest.h

--- a/include/GCDWebServers/GCDWebServerDataResponse.h
+++ b/include/GCDWebServers/GCDWebServerDataResponse.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Responses/GCDWebServerDataResponse.h

--- a/include/GCDWebServers/GCDWebServerErrorResponse.h
+++ b/include/GCDWebServers/GCDWebServerErrorResponse.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Responses/GCDWebServerErrorResponse.h

--- a/include/GCDWebServers/GCDWebServerFileRequest.h
+++ b/include/GCDWebServers/GCDWebServerFileRequest.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Requests/GCDWebServerFileRequest.h

--- a/include/GCDWebServers/GCDWebServerFileResponse.h
+++ b/include/GCDWebServers/GCDWebServerFileResponse.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Responses/GCDWebServerFileResponse.h

--- a/include/GCDWebServers/GCDWebServerFunctions.h
+++ b/include/GCDWebServers/GCDWebServerFunctions.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Core/GCDWebServerFunctions.h

--- a/include/GCDWebServers/GCDWebServerHTTPStatusCodes.h
+++ b/include/GCDWebServers/GCDWebServerHTTPStatusCodes.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h

--- a/include/GCDWebServers/GCDWebServerMultiPartFormRequest.h
+++ b/include/GCDWebServers/GCDWebServerMultiPartFormRequest.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.h

--- a/include/GCDWebServers/GCDWebServerRequest.h
+++ b/include/GCDWebServers/GCDWebServerRequest.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Core/GCDWebServerRequest.h

--- a/include/GCDWebServers/GCDWebServerResponse.h
+++ b/include/GCDWebServers/GCDWebServerResponse.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Core/GCDWebServerResponse.h

--- a/include/GCDWebServers/GCDWebServerStreamedResponse.h
+++ b/include/GCDWebServers/GCDWebServerStreamedResponse.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Responses/GCDWebServerStreamedResponse.h

--- a/include/GCDWebServers/GCDWebServerURLEncodedFormRequest.h
+++ b/include/GCDWebServers/GCDWebServerURLEncodedFormRequest.h
@@ -1,0 +1,1 @@
+../../GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.h

--- a/include/GCDWebServers/GCDWebUploader.h
+++ b/include/GCDWebServers/GCDWebUploader.h
@@ -1,0 +1,1 @@
+../../GCDWebUploader/GCDWebUploader.h


### PR DESCRIPTION
This PR should include everything to fully support SPM. That includes:
- Public headers for the module (realised using symbolic links)
- Deals with GCDWebUploader.bundle
- Other build methods should not be affected (Xcode, Cocoapods)