### PR TITLE
Update minimum iOS deployment target to iOS 9.0

### DIFF
--- a/GCDWebServer.podspec
+++ b/GCDWebServer.podspec
@@ -7,14 +7,14 @@
 
 Pod::Spec.new do |s|
   s.name     = 'GCDWebServer'
-  s.version  = '3.5.4'
+  s.version  = '3.6.0'
   s.author   =  { 'Pierre-Olivier Latour' => 'info@pol-online.net' }
   s.license  = { :type => 'BSD', :file => 'LICENSE' }
   s.homepage = 'https://github.com/swisspol/GCDWebServer'
   s.summary  = 'Lightweight GCD based HTTP server for OS X & iOS (includes web based uploader & WebDAV server)'
   
   s.source   = { :git => 'https://github.com/swisspol/GCDWebServer.git', :tag => s.version.to_s }
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.osx.deployment_target = '10.7'
   s.requires_arc = true

--- a/GCDWebServer.podspec
+++ b/GCDWebServer.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name     = 'GCDWebServer'
-  s.version  = '3.6.0'
+  s.version  = '3.5.4'
   s.author   =  { 'Pierre-Olivier Latour' => 'info@pol-online.net' }
   s.license  = { :type => 'BSD', :file => 'LICENSE' }
   s.homepage = 'https://github.com/swisspol/GCDWebServer'

--- a/GCDWebServer.xcodeproj/project.pbxproj
+++ b/GCDWebServer.xcodeproj/project.pbxproj
@@ -1260,7 +1260,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Frameworks/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Frameworks/module.modulemap;
 				PRODUCT_NAME = GCDWebServers;
@@ -1278,7 +1278,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Frameworks/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Frameworks/module.modulemap;
 				PRODUCT_NAME = GCDWebServers;
@@ -1412,7 +1412,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = GCDWebServer;
 				SDKROOT = iphoneos;
@@ -1426,7 +1426,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = GCDWebServer;
 				SDKROOT = iphoneos;

--- a/Run-Tests.sh
+++ b/Run-Tests.sh
@@ -69,7 +69,7 @@ xcodebuild build -sdk "$OSX_SDK" -target "$OSX_TARGET" -configuration "$CONFIGUR
 
 # Build for iOS for oldest supported deployment target
 rm -rf "$BUILD_DIR"
-xcodebuild build -sdk "$IOS_SDK" -target "$IOS_TARGET" -configuration "$CONFIGURATION" "SYMROOT=$BUILD_DIR" "IPHONEOS_DEPLOYMENT_TARGET=8.0" | $PRETTYFIER
+xcodebuild build -sdk "$IOS_SDK" -target "$IOS_TARGET" -configuration "$CONFIGURATION" "SYMROOT=$BUILD_DIR" "IPHONEOS_DEPLOYMENT_TARGET=9.0" | $PRETTYFIER
 
 # Build for iOS for current deployment target
 rm -rf "$BUILD_DIR"


### PR DESCRIPTION
Xcode 12 no longer supports iOS 8 and throws warnings if any frameworks use a lower minimum deployment target. This PR updates the deployment target in both the podspec as well as the run tests. I didn't see any other places it needs to be updated but am happy to update other locations if they exist. 

I've included a minor version bump in the podspec since this is a semi-breaking change as it will no longer support anyone who is developing for iOS 8 - although since Apple doesn't support that type of development anyway it seems unlikely and therefore not worthy of a major bump. 